### PR TITLE
Loading and end feedback

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -137,7 +137,7 @@
 	text-align: center;
 	z-index: 100;
 	position: relative;
-	left: 45%;
+	margin: 0 auto;
 	bottom: 20px;
 	width: 200px;
 	padding: 50px 0;


### PR DESCRIPTION
- push loading feedback to end of list so it doesn't obstruct
- make clear when Activity stream ends: keep »No more activities to load.« displayed permanently and with a bit more space below

@nickvergessen @karlitschek 
