### PR TITLE
Working with other apps where are not types = file

### DIFF
--- a/lib/display.php
+++ b/lib/display.php
@@ -51,7 +51,9 @@ class Display
 		$tmpl->assign('event', $activity);
 
 		$rootView = new \OC\Files\View('');
-		if ($activity['file'] !== null){
+	       if ($activity['file'] !== null && $activity['file']!==''){
+			$rootView = new \OC\Files\View('');
+			
 			$exist = $rootView->file_exists('/' . $activity['user'] . '/files' . $activity['file']);
 			$is_dir = $rootView->is_dir('/' . $activity['user'] . '/files' . $activity['file']);
 			unset($rootView);


### PR DESCRIPTION
Problem: If you add an activity from calendar or other app you have always the folder shown!
With this it only shows the preview or folder if type is file!
