### PR TITLE
Change user, affecteduser from varchar 255 to 64

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -165,7 +165,7 @@
 				<name>amq_affecteduser</name>
 				<type>text</type>
 				<notnull>true</notnull>
-				<length>255</length>
+				<length>64</length>
 			</field>
 			<field>
 				<name>amq_appid</name>


### PR DESCRIPTION
cause if you are looking in the oc_user table the uid and displayname column have a max of varchar(64) so the max for you also varchar(64)
if not you are running with some databases in following error

```
innoDB': SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 1000 bytes
```
