### PR TITLE
never show a scrollbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10,13 +10,13 @@
 	margin-bottom: 5px;
 	margin-left: 5px;
 	text-overflow: ellipsis;
-	overflow-x: hidden;
+	overflow: hidden;
 }
 .activitymessage {
 	font-size:0.8em;
 	color:#666;
 	text-overflow: ellipsis;
-	overflow-x: hidden;
+	overflow: hidden;
 }
 
 #no_activities {


### PR DESCRIPTION
see the gray bars at the screenshot below? That's a tiny scrollbar because the avatar is to high. This PR fixes it. I think we should never have a scrollbar for single activities.

![screenshot](https://cloud.githubusercontent.com/assets/1589737/3628448/6d9b6aea-0e94-11e4-8fb9-20d58c828679.png)

cc @nickvergessen @jancborchardt @PVince81 
