### PR TITLE
remove obsolete japanese lang code

### DIFF
--- a/l10n/ja_JP.php
+++ b/l10n/ja_JP.php
@@ -1,8 +1,0 @@
-<?php $TRANSLATIONS = array(
-"Activity" => "アクティビティ",
-"No more activities to load." => "これ以上読み込むアクティビティはありません。",
-"Loading older activities" => "古いアクティビティを読み込み中",
-"RSS feed" => "RSSフィード",
-"No activities yet." => "アクティビティはまだありません。",
-"You will see a list of events here when you start to use your %s." => "%s の使用を開始すると、ここでイベントリストを見ることができます。"
-);


### PR DESCRIPTION
Similar to https://github.com/owncloud/core/pull/10312.

We only have `ja.php` files. The other one is outdated.
