### PR TITLE
Correctly use the recipients language in emails for the body

### DIFF
--- a/lib/mailqueuehandler.php
+++ b/lib/mailqueuehandler.php
@@ -178,6 +178,7 @@ class MailQueueHandler {
 		$alttext->assign('timeframe', $this->getLangForApproximatedTimeFrame($mailData[0]['amq_timestamp']));
 		$alttext->assign('activities', $activityList);
 		$alttext->assign('owncloud_installation', \OC_Helper::makeURLAbsolute('/'));
+		$alttext->assign('overwriteL10N', $l);
 		$emailText = $alttext->fetchPage();
 
 		try {

--- a/templates/email.notification.php
+++ b/templates/email.notification.php
@@ -5,6 +5,7 @@
 
 /** @var OC_L10N $l */
 /** @var array $_ */
+$l = $_['overwriteL10N'];
 
 print_unescaped($l->t('Hello %s,', array($_['username'])));
 p("\n");


### PR DESCRIPTION
Since we use the template for the emails the body sometimes was displayed in
the language of the user, who triggered the email, rather then the recipient.

In order to be able to do this correctly, we need to pass in the actual
language and use that, instead of the language from the template engine.

Fix #145 

@enoch85 @PVince81 
