### PR TITLE
do not show alt text for previews, not necessary

### DIFF
--- a/templates/activity.box.php
+++ b/templates/activity.box.php
@@ -29,7 +29,7 @@
 
 		<?php if (!empty($_['previewImageLink'])): ?>
 			<?php if ($_['previewLink']): ?><a href="<?php p($_['previewLink']) ?>"><?php endif ?>
-			<img class="preview<?php if (!empty($_['previewLinkIsDir'])): ?> preview-dir-icon<?php endif ?>" src="<?php p($_['previewImageLink']) ?>" alt="<?php p($_['event']['subjectformatted']['trimmed']) ?>"/>
+			<img class="preview<?php if (!empty($_['previewLinkIsDir'])): ?> preview-dir-icon<?php endif ?>" src="<?php p($_['previewImageLink']) ?>" alt=""/>
 			<?php if ($_['previewLink']): ?></a><?php endif; ?>
 		<?php endif ?>
 


### PR DESCRIPTION
Keep the alt tag empty if not needed! Especially when it is just duplicated text.

This created some layout errors and needs to be backported. Please review @nickvergessen 
