### PR TITLE
Remove copyright from email template

### DIFF
--- a/templates/email.notification.php
+++ b/templates/email.notification.php
@@ -1,8 +1,4 @@
 <?php
-/* Copyright (c) 2014, Joas Schilling nickvergessen@owncloud.com
- * This file is licensed under the Affero General Public License version 3
- * or later. See the COPYING-README file. */
-
 /** @var OC_L10N $l */
 /** @var array $_ */
 $l = $_['overwriteL10N'];


### PR DESCRIPTION
This helps to have a cleaner view in the email template editor
