### PR TITLE
only define PHPUNIT_RUN if undefined

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,9 @@
 global $RUNTIME_NOAPPS;
 $RUNTIME_NOAPPS = true;
 
-define('PHPUNIT_RUN', 1);
+if (!defined('PHPUNIT_RUN')) {
+	define('PHPUNIT_RUN', 1);
+}
 
 require_once __DIR__.'/../../../lib/base.php';
 


### PR DESCRIPTION
otherwise I get a warning when running the testsuite:

```
PHP Notice:  Constant PHPUNIT_RUN already defined in /home/jfd/Repositories/oc/core/apps-repos/activity/tests/bootstrap.php on line 6
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:46
PHP   3. PHPUnit_TextUI_Command->run() /usr/share/php/PHPUnit/TextUI/Command.php:129
PHP   4. PHPUnit_TextUI_Command->handleArguments() /usr/share/php/PHPUnit/TextUI/Command.php:138
PHP   5. PHPUnit_Util_Configuration->getTestSuiteConfiguration() /usr/share/php/PHPUnit/TextUI/Command.php:657
PHP   6. PHPUnit_Util_Configuration->getTestSuite() /usr/share/php/PHPUnit/Util/Configuration.php:789
PHP   7. PHPUnit_Framework_TestSuite->addTestFile() /usr/share/php/PHPUnit/Util/Configuration.php:912
PHP   8. PHPUnit_Util_Fileloader::checkAndLoad() /usr/share/php/PHPUnit/Framework/TestSuite.php:355
PHP   9. PHPUnit_Util_Fileloader::load() /usr/share/php/PHPUnit/Util/Fileloader.php:76
PHP  10. include_once() /usr/share/php/PHPUnit/Util/Fileloader.php:92
PHP  11. loadDirectory() /home/jfd/Repositories/oc/core/tests/apps.php:39
PHP  12. require_once() /home/jfd/Repositories/oc/core/tests/apps.php:17
PHP  13. define() /home/jfd/Repositories/oc/core/apps-repos/activity/tests/bootstrap.php:6
```
