### PR TITLE
Always prepareParameters and allow extensions to specify the specialParams

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -22,14 +22,16 @@
 
 namespace OCA\Activity\AppInfo;
 
-use \OCP\AppFramework\App;
-use \OCP\IContainer;
-use \OCA\Activity\Data;
-use \OCA\Activity\DataHelper;
-use \OCA\Activity\GroupHelper;
-use \OCA\Activity\UserSettings;
-use \OCA\Activity\Controller\Activities;
-use \OCA\Activity\Controller\Settings;
+use OC\Files\View;
+use OCA\Activity\Controller\Activities;
+use OCA\Activity\Controller\Settings;
+use OCA\Activity\Data;
+use OCA\Activity\DataHelper;
+use OCA\Activity\GroupHelper;
+use OCA\Activity\ParameterHelper;
+use OCA\Activity\UserSettings;
+use OCP\AppFramework\App;
+use OCP\IContainer;
 
 class Application extends App {
 	public function __construct (array $urlParams=[]) {
@@ -57,9 +59,15 @@ class Application extends App {
 		});
 
 		$container->registerService('DataHelper', function(IContainer $c) {
+			/** @var \OC\Server $server */
+			$server = $c->query('ServerContainer');
 			return new DataHelper(
-				$c->query('ServerContainer')->query('ActivityManager'),
-				new \OCA\Activity\ParameterHelper(new \OC\Files\View(''), $c->query('ActivityL10N')),
+				$server->query('ActivityManager'),
+				new ParameterHelper (
+					$server->query('ActivityManager'),
+					new View(''),
+					$c->query('ActivityL10N')
+				),
 				$c->query('ActivityL10N')
 			);
 		});

--- a/lib/api.php
+++ b/lib/api.php
@@ -40,7 +40,11 @@ class Api
 			\OC::$server->getActivityManager(),
 			new \OCA\Activity\DataHelper(
 				\OC::$server->getActivityManager(),
-				new \OCA\Activity\ParameterHelper(new \OC\Files\View(''), $l),
+				new \OCA\Activity\ParameterHelper(
+					\OC::$server->getActivityManager(),
+					new \OC\Files\View(''),
+					$l
+				),
 				$l
 			),
 			false

--- a/lib/datahelper.php
+++ b/lib/datahelper.php
@@ -26,8 +26,7 @@ namespace OCA\Activity;
 use \OCP\Util;
 use \OCP\Activity\IManager;
 
-class DataHelper
-{
+class DataHelper {
 	/** @var \OCP\Activity\IManager */
 	protected $activityManager;
 
@@ -59,11 +58,12 @@ class DataHelper
 			return '';
 		}
 
+		$preparedParams = $this->parameterHelper->prepareParameters(
+			$params, $this->parameterHelper->getSpecialParameterList($app, $text),
+			$stripPath, $highlightParams
+		);
+
 		if ($app === 'files') {
-			$preparedParams = $this->parameterHelper->prepareParameters(
-				$params, $this->parameterHelper->getSpecialParameterList($app, $text),
-				$stripPath, $highlightParams
-			);
 			switch ($text) {
 				case 'created_self':
 					return $this->l->t('You created %1$s', $preparedParams);
@@ -96,14 +96,14 @@ class DataHelper
 
 		// Allow other apps to correctly translate their activities
 		$translation = $this->activityManager->translate(
-			$app, $text, $params, $stripPath, $highlightParams, $this->l->getLanguageCode());
+			$app, $text, $preparedParams, $stripPath, $highlightParams, $this->l->getLanguageCode());
 
 		if ($translation !== false) {
 			return $translation;
 		}
 
 		$l = Util::getL10N($app);
-		return $l->t($text, $params);
+		return $l->t($text, $preparedParams);
 	}
 
 	/**

--- a/lib/mailqueuehandler.php
+++ b/lib/mailqueuehandler.php
@@ -165,7 +165,15 @@ class MailQueueHandler {
 	 */
 	public function sendEmailToUser($user, $email, $lang, $timezone, $mailData) {
 		$l = $this->getLanguage($lang);
-		$dataHelper = new DataHelper(\OC::$server->getActivityManager(), new ParameterHelper(new \OC\Files\View(''), $l), $l);
+		$dataHelper = new DataHelper(
+			\OC::$server->getActivityManager(),
+			new ParameterHelper(
+				\OC::$server->getActivityManager(),
+				new \OC\Files\View(''),
+				$l
+			),
+			$l
+		);
 
 		$activityList = array();
 		foreach ($mailData as $activity) {

--- a/lib/parameterhelper.php
+++ b/lib/parameterhelper.php
@@ -23,19 +23,23 @@
 
 namespace OCA\Activity;
 
-use \OCP\User;
-use \OCP\Util;
-use \OC\Files\View;
+use OCP\Activity\IManager;
+use OCP\User;
+use OCP\Util;
+use OC\Files\View;
 
-class ParameterHelper
-{
+class ParameterHelper {
+	/** @var \OCP\Activity\IManager */
+	protected $activityManager;
+
 	/** @var \OC\Files\View */
 	protected $rootView;
 
 	/** @var \OC_L10N */
 	protected $l;
 
-	public function __construct(View $rootView, \OC_L10N $l) {
+	public function __construct(IManager $activityManager, View $rootView, \OC_L10N $l) {
+		$this->activityManager = $activityManager;
 		$this->rootView = $rootView;
 		$this->l = $l;
 	}
@@ -274,6 +278,13 @@ class ParameterHelper
 		else if ($app === 'files') {
 			return array(0 => 'file', 1 => 'username');
 		}
+
+		$specialParameters = $this->activityManager->getSpecialParameterList($app, $text);
+
+		if ($specialParameters !== false) {
+			return $specialParameters;
+		}
+
 		return array();
 	}
 }

--- a/rss.php
+++ b/rss.php
@@ -63,7 +63,11 @@ $groupHelper = new \OCA\Activity\GroupHelper(
 	\OC::$server->getActivityManager(),
 	new \OCA\Activity\DataHelper(
 		\OC::$server->getActivityManager(),
-		new \OCA\Activity\ParameterHelper(new \OC\Files\View(''), $l),
+		new \OCA\Activity\ParameterHelper(
+			\OC::$server->getActivityManager(),
+			new \OC\Files\View(''),
+			$l
+		),
 		$l
 	),
 	false

--- a/tests/datahelpertest.php
+++ b/tests/datahelpertest.php
@@ -129,6 +129,7 @@ class DataHelperTest extends TestCase {
 		$dataHelper = new \OCA\Activity\DataHelper(
 			$this->getMock('\OCP\Activity\IManager'),
 			new \OCA\Activity\ParameterHelper(
+				$this->getMock('\OCP\Activity\IManager'),
 				new \OC\Files\View(''),
 				\OCP\Util::getL10N('activity')
 			),

--- a/tests/grouphelpertest.php
+++ b/tests/grouphelpertest.php
@@ -486,6 +486,7 @@ class GroupHelperTest extends TestCase {
 			new DataHelper(
 				$activityManager,
 				new ParameterHelper(
+					$activityManager,
 					new \OC\Files\View(''),
 					$activityLanguage
 				),

--- a/tests/parameterhelpertest.php
+++ b/tests/parameterhelpertest.php
@@ -37,7 +37,15 @@ class ParameterHelperTest extends TestCase {
 		\OC::$WEBROOT = '';
 		$l = \OCP\Util::getL10N('activity');
 		$this->view = new \OC\Files\View('');
-		$this->parameterHelper = new \OCA\Activity\ParameterHelper($this->view, $l);
+		$manager = $this->getMock('\OCP\Activity\IManager');
+		$manager->expects($this->any())
+			->method('getSpecialParameterList')
+			->will($this->returnValue(false));
+		$this->parameterHelper = new \OCA\Activity\ParameterHelper(
+			$manager,
+			$this->view,
+			$l
+		);
 	}
 
 	protected function tearDown() {


### PR DESCRIPTION
- [x] Requires owncloud/core#12788

Always prepares parameters to avoid potential XSS and allows extensions to specify special parameters, eg username (adds avatar) file (moves path to tooltip)

@DeepDiver1975 @LukasReschke @schiesbn 
