### PR TITLE
Fix the success msgs in the personal settings page

### DIFF
--- a/controller/settings.php
+++ b/controller/settings.php
@@ -135,7 +135,7 @@ class Settings extends Controller {
 		return new DataResponse(array(
 			'status'	=>'success',
 			'data'		=> array(
-				'message'	=> $this->l10n->t('Your settings have been updated.'),
+				'message'	=> (string) $this->l10n->t('Your settings have been updated.'),
 			),
 		));
 	}
@@ -202,7 +202,7 @@ class Settings extends Controller {
 		return new DataResponse(array(
 			'status'	=>'success',
 			'data'		=> array(
-				'message'	=> $this->l10n->t('Your settings have been updated.'),
+				'message'	=> (string) $this->l10n->t('Your settings have been updated.'),
 				'rsslink'	=> $tokenUrl,
 			),
 		));


### PR DESCRIPTION
Currently the success message is not displayed:
![owncloud_-_2015-01-14_17 24 14](https://cloud.githubusercontent.com/assets/213943/5742440/6b15f586-9c12-11e4-98e2-23e9dd235f49.png)

Fixed:
![owncloud_-_2015-01-14_17 26 23](https://cloud.githubusercontent.com/assets/213943/5742463/94052f5c-9c12-11e4-9633-4d670747c2e5.png)

@LukasReschke 