### PR TITLE
Use a valid timezone name when no timezone is set

### DIFF
--- a/lib/backgroundjob/emailnotification.php
+++ b/lib/backgroundjob/emailnotification.php
@@ -101,7 +101,7 @@ class EmailNotification extends \OC\BackgroundJob\TimedJob {
 			}
 
 			$language = (isset($userLanguages[$user])) ? $userLanguages[$user] : $default_lang;
-			$timezone = (isset($userTimezones[$user])) ? $userTimezones[$user] : '';
+			$timezone = (isset($userTimezones[$user])) ? $userTimezones[$user] : 'UTC';
 			$this->mqHandler->sendEmailToUser($user, $userEmails[$user], $language, $timezone, $data);
 		}
 


### PR DESCRIPTION
We create a TimeZone object from the value directly:
https://github.com/owncloud/activity/blob/83865de1b1285f4c4540f4047fba86cfbee4ee6d/lib/mailqueuehandler.php#L196
See log in https://github.com/owncloud/core/issues/14176

@LukasReschke 