### PR TITLE
Use displayname instead of username in the To: field of activity emails

### DIFF
--- a/lib/mailqueuehandler.php
+++ b/lib/mailqueuehandler.php
@@ -214,7 +214,7 @@ class MailQueueHandler {
 
 		try {
 			\OCP\Util::sendMail(
-				$email, $user,
+				$email, \OCP\User::getDisplayName($user),
 				$l->t('Activity notification'), $emailText,
 				$this->getSenderData('email'), $this->getSenderData('name')
 			);


### PR DESCRIPTION
I'm using AD as backend for authentication. Activity notification emails are sent to users hourly. Users see that emails are sent to:

To: D501C74A-3BD8-437C-A0AB-D80BA42E1436 <myemail@mydomain.com>

Instead of:

To: Luca Lorenzetto <myemail@mydomain.com>

This is because LDAP authentication backend uses Active Directory GIDs as owncloud usernames (even if the user inserts on the login page it's own active directory account name like "myusername"). LDAP backend populates the display name attribute, which is the most appropriate field for the "To:" email field.
