### PR TITLE
[Stable7] Use displayname as user name for email recipient

### DIFF
--- a/lib/mailqueuehandler.php
+++ b/lib/mailqueuehandler.php
@@ -186,7 +186,7 @@ class MailQueueHandler {
 
 		try {
 			\OCP\Util::sendMail(
-				$email, $user,
+				$email, \OCP\User::getDisplayName($user),
 				$l->t('Activity notification'), $emailText,
 				$this->getSenderData('email'), $this->getSenderData('name')
 			);


### PR DESCRIPTION
Backport of #251 (master), #252 (stable8)
@karlitschek @DeepDiver1975 please approve backport to 7

@scolebrook 