### PR TITLE
Fix OCC app:check-code complains

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -128,6 +128,7 @@ class Application extends App {
 				$server->getDatabaseConnection(),
 				$c->query('DataHelper'),
 				$server->getMailer(),
+				$server->getURLGenerator(),
 				$server->getUserManager()
 			);
 		});

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,8 +23,10 @@
 
 namespace OCA\Activity\AppInfo;
 
+use OCP\API;
+
 // Register an OCS API call
-\OC_API::register(
+API::register(
 	'get',
 	'/cloud/activity',
 	array('OCA\Activity\Api', 'get'),

--- a/lib/display.php
+++ b/lib/display.php
@@ -90,8 +90,8 @@ class Display {
 			$is_dir = $this->view->is_dir($activity['file']);
 
 			// show a preview image if the file still exists
-			$mimetype = \OC_Helper::getFileNameMimeType($activity['file']);
-			if (!$is_dir && $this->preview->isMimeSupported($mimetype) && $exist) {
+			$mimeType = \OCP\Files::getMimeType($activity['file']);
+			if ($mimeType && !$is_dir && $this->preview->isMimeSupported($mimeType) && $exist) {
 				$tmpl->assign('previewLink', $this->urlGenerator->linkTo('files', 'index.php', array('dir' => dirname($activity['file']))));
 				$tmpl->assign('previewImageLink',
 					$this->urlGenerator->linkToRoute('core_ajax_preview', array(
@@ -102,7 +102,7 @@ class Display {
 				);
 			} else {
 				$tmpl->assign('previewLink', Util::linkTo('files', 'index.php', array('dir' => $activity['file'])));
-				$tmpl->assign('previewImageLink', \OC_Helper::mimetypeIcon($is_dir ? 'dir' : $mimetype));
+				$tmpl->assign('previewImageLink', Template::mimetype_icon($is_dir ? 'dir' : $mimeType));
 				$tmpl->assign('previewLinkIsDir', true);
 			}
 		}

--- a/lib/mailqueuehandler.php
+++ b/lib/mailqueuehandler.php
@@ -26,6 +26,7 @@ namespace OCA\Activity;
 use OCP\Defaults;
 use OCP\IDateTimeFormatter;
 use OCP\IDBConnection;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
@@ -63,6 +64,12 @@ class MailQueueHandler {
 	/** @var IMailer */
 	protected $mailer;
 
+	/** @var IURLGenerator */
+	protected $urlGenerator;
+
+	/** @var IUserManager */
+	protected $userManager;
+
 	/**
 	 * Constructor
 	 *
@@ -70,17 +77,20 @@ class MailQueueHandler {
 	 * @param IDBConnection $connection
 	 * @param DataHelper $dataHelper
 	 * @param IMailer $mailer
+	 * @param IURLGenerator $urlGenerator
 	 * @param IUserManager $userManager
 	 */
 	public function __construct(IDateTimeFormatter $dateFormatter,
 								IDBConnection $connection,
 								DataHelper $dataHelper,
 								IMailer $mailer,
+								IURLGenerator $urlGenerator,
 								IUserManager $userManager) {
 		$this->dateFormatter = $dateFormatter;
 		$this->connection = $connection;
 		$this->dataHelper = $dataHelper;
 		$this->mailer = $mailer;
+		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
 	}
 
@@ -246,7 +256,7 @@ class MailQueueHandler {
 		$alttext->assign('timeframe', $this->getLangForApproximatedTimeFrame($mailData[0]['amq_timestamp']));
 		$alttext->assign('activities', $activityList);
 		$alttext->assign('skippedCount', $skippedCount);
-		$alttext->assign('owncloud_installation', \OC_Helper::makeURLAbsolute('/'));
+		$alttext->assign('owncloud_installation', $this->urlGenerator->getAbsoluteURL('/'));
 		$alttext->assign('overwriteL10N', $l);
 		$emailText = $alttext->fetchPage();
 

--- a/tests/mailqueuehandlertest.php
+++ b/tests/mailqueuehandlertest.php
@@ -73,6 +73,9 @@ class MailQueueHandlerTest extends TestCase {
 				->disableOriginalConstructor()
 				->getMock(),
 			$this->mailer,
+			$this->getMockBuilder('\OCP\IURLGenerator')
+				->disableOriginalConstructor()
+				->getMock(),
 			$this->userManager
 		);
 	}


### PR DESCRIPTION
- [x] Requires: https://github.com/owncloud/core/pull/15717

Fix #282

I don't feel very comfortable replacing the following calls, because they are testing specific and don't have a public replacement @DeepDiver1975 

1. `\OC_User::setUserId($user);`
    ```
Analysing /home/nickv/ownCloud/master/repos/activity/tests/apitest.php
 1 errors
    line  153: OC_User - static method call on private class
```

2. `OC_Hook::clear();`
    ```
Analysing /home/nickv/ownCloud/master/repos/activity/tests/bootstrap.php
 1 errors
    line   16: OC_Hook - static method call on private class
```