### PR TITLE
Backport 271 stream notself

### DIFF
--- a/lib/data.php
+++ b/lib/data.php
@@ -215,7 +215,7 @@ class Data
 			$limitActivities .= ' AND `user` = ?';
 			$parameters[] = $user;
 		}
-		else if ($filter === 'by') {
+		else if ($filter === 'by' || $filter === 'all' && !$userSettings->getUserSetting($user, 'setting', 'self')) {
 			$limitActivities .= ' AND `user` <> ?';
 			$parameters[] = $user;
 		}

--- a/lib/display.php
+++ b/lib/display.php
@@ -48,7 +48,7 @@ class Display
 		$tmpl->assign('user', $activity['user']);
 		$tmpl->assign('displayName', User::getDisplayName($activity['user']));
 
-		if ($activity['app'] === 'files') {
+		if (strpos($activity['subjectformatted']['markup']['trimmed'], '<a ') !== false) {
 			// We do not link the subject as we create links for the parameters instead
 			$activity['link'] = '';
 		}


### PR DESCRIPTION
Fix #289 

Backporting the fixes from #271 

@karlitschek please approve
@MorrisJobke mind reviewing/testing ;)

**Testplan:**
1. Check the box in personal settings so you get self actions
2. Create some activities
3. Uncheck the box
4. Verify no selfactions are displayed on the stream and RSS feed anymore

The second commit (display.php) does not affect existing activities of the activity app, but it might affect some other apps' activities