### PR TITLE
Replace tipsy with tooltip and use a different classname

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -121,9 +121,9 @@ $(function(){
 				element.avatar(element.data('user'), 28);
 			});
 
-			$(parentElement).find('.tooltip').tipsy({
-				gravity: 'n'
-			});
+			$(parentElement).find('.has-tooltip').tooltip({
+				placement: 'bottom'
+			})
 		}
 	};
 

--- a/lib/parameterhelper.php
+++ b/lib/parameterhelper.php
@@ -237,7 +237,7 @@ class ParameterHelper {
 
 		if ($highlightParams) {
 			$title = ' title="' . Util::sanitizeHTML($federatedCloudId) . '"';
-			return '<strong class="tooltip"' . $title . '>' . Util::sanitizeHTML($displayName) . '</strong>';
+			return '<strong class="has-tooltip"' . $title . '>' . Util::sanitizeHTML($displayName) . '</strong>';
 		} else {
 			return $displayName;
 		}
@@ -316,7 +316,7 @@ class ParameterHelper {
 		}
 
 		$title = ' title="' . $this->l->t('in %s', array(Util::sanitizeHTML($path))) . '"';
-		return '<a class="filename tooltip" href="' . $fileLink . '"' . $title . '>' . Util::sanitizeHTML($name) . '</a>';
+		return '<a class="filename has-tooltip" href="' . $fileLink . '"' . $title . '>' . Util::sanitizeHTML($name) . '</a>';
 	}
 
 	/**
@@ -391,10 +391,10 @@ class ParameterHelper {
 		$trimmedList = implode($this->l->t(', '), $trimmedParams);
 		if ($highlightParams) {
 			return $this->l->n(
-				'%s and <strong class="tooltip" title="%s">%n more</strong>',
-				'%s and <strong class="tooltip" title="%s">%n more</strong>',
+				'%s and <strong %s>%n more</strong>',
+				'%s and <strong %s>%n more</strong>',
 				$count - 3,
-				array($firstList, Util::sanitizeHTML($trimmedList)));
+				array($firstList, 'class="has-tooltip" title="' . Util::sanitizeHTML($trimmedList) . '"'));
 		}
 		return $this->l->n('%s and %n more', '%s and %n more', $count - 3, array($firstList));
 	}

--- a/templates/stream.item.php
+++ b/templates/stream.item.php
@@ -17,7 +17,7 @@
 			<?php if ($_['event']['link']): ?></a><?php endif; ?>
 		</div>
 
-		<span class="activitytime tooltip" title="<?php p($_['formattedDate']) ?>">
+		<span class="activitytime has-tooltip" title="<?php p($_['formattedDate']) ?>">
 			<?php p($_['formattedTimestamp']) ?>
 		</span>
 

--- a/templates/stream.list.php
+++ b/templates/stream.list.php
@@ -49,7 +49,7 @@ foreach ($_['activity'] as $event) {
 ?>
 <div class="section activity-section group" data-date="<?php p($currentDate) ?>">
 	<h2>
-		<span class="tooltip" title="<?php p($dateTimeFormatter->formatDate($event['timestamp'])) ?>">
+		<span class="has-tooltip" title="<?php p($dateTimeFormatter->formatDate($event['timestamp'])) ?>">
 			<?php p(ucfirst($currentDate)) ?>
 		</span>
 	</h2>

--- a/tests/datahelpertest.php
+++ b/tests/datahelpertest.php
@@ -58,7 +58,7 @@ class DataHelperTest extends TestCase {
 			),
 			array(
 				'subject1', array('/SubFolder/A.txt'), true, true,
-				'Subject1 #<a class="filename tooltip" href="/index.php/apps/files?dir=%2FSubFolder&scrollto=A.txt" title="in SubFolder">A.txt</a>',
+				'Subject1 #<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FSubFolder&scrollto=A.txt" title="in SubFolder">A.txt</a>',
 			),
 
 			array('subject2', array('/SubFolder/A.txt', 'UserB'), false, false, 'Subject2 @UserB #SubFolder/A.txt'),
@@ -71,7 +71,7 @@ class DataHelperTest extends TestCase {
 			array(
 				'subject2', array('/SubFolder/A.txt', 'UserB'), true, true,
 				'Subject2 @<div class="avatar" data-user="UserB"></div><strong>UserB</strong> #'
-				. '<a class="filename tooltip" href="/index.php/apps/files?dir=%2FSubFolder&scrollto=A.txt" title="in SubFolder">A.txt</a>',
+				. '<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FSubFolder&scrollto=A.txt" title="in SubFolder">A.txt</a>',
 			),
 			array(
 				'subject2', array('/A.txt', 'UserB'), true, true,
@@ -122,7 +122,7 @@ class DataHelperTest extends TestCase {
 				'Subject1 #<a class="filename" href="/index.php/apps/files?dir=%2FSubFolder&scrollto=A.txt">SubFolder/A.txt</a>,'
 				. ' <a class="filename" href="/index.php/apps/files?dir=%2FSubFolder&scrollto=B.txt">SubFolder/B.txt</a>,'
 				. ' <a class="filename" href="/index.php/apps/files?dir=%2FSubFolder&scrollto=C.txt">SubFolder/C.txt</a>'
-				. ' and <strong class="tooltip" title="SubFolder/D.txt, SubFolder/E.txt, SubFolder/F.txt">3 more</strong>',
+				. ' and <strong class="has-tooltip" title="SubFolder/D.txt, SubFolder/E.txt, SubFolder/F.txt">3 more</strong>',
 			),
 		);
 	}

--- a/tests/parameterhelpertest.php
+++ b/tests/parameterhelpertest.php
@@ -138,10 +138,10 @@ class ParameterHelperTest extends TestCase {
 			array(array('/foo/bar.file'), array(0 => 'file'), false, false, array('foo/bar.file')),
 			array(array('/folder/trailingslash/fromsharing/'), array(0 => 'file'), false, false, array('folder/trailingslash/fromsharing')),
 			array(array('/foo/bar.file'), array(0 => 'file'), true, true, array(
-				'<a class="filename tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
+				'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
 			)),
 			array(array('/0/bar.file'), array(0 => 'file'), true, true, array(
-				'<a class="filename tooltip" href="/index.php/apps/files?dir=%2F0&scrollto=bar.file" title="in 0">bar.file</a>',
+				'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2F0&scrollto=bar.file" title="in 0">bar.file</a>',
 			)),
 			array(array('/foo/bar.file'), array(1 => 'file'), true, false, array('/foo/bar.file')),
 			array(array('/foo/bar.file'), array(1 => 'file'), true, true, array('<strong>/foo/bar.file</strong>')),
@@ -153,14 +153,14 @@ class ParameterHelperTest extends TestCase {
 			)),
 			array(array('foo/bar.file'), array(0 => 'file'), true, false, array('bar.file')),
 			array(array('foo/bar.file'), array(0 => 'file'), true, true, array(
-				'<a class="filename tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
+				'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
 			)),
 
 			// Valid file position
 			array(array('UserA', '/foo/bar.file'), array(1 => 'file'), true, false, array('UserA', 'bar.file')),
 			array(array('UserA', '/foo/bar.file'), array(1 => 'file'), true, true, array(
 				'<strong>UserA</strong>',
-				'<a class="filename tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
+				'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
 			)),
 			array(array('UserA', '/foo/bar.file'), array(2 => 'file'), true, false, array('UserA', '/foo/bar.file')),
 			array(array('UserA', '/foo/bar.file'), array(2 => 'file'), true, true, array(
@@ -191,11 +191,11 @@ class ParameterHelperTest extends TestCase {
 
 			array(array('user1', '/foo/bar.file'), array(0 => 'username', 1 => 'file'), true, true, array(
 				'<div class="avatar" data-user="user1"></div><strong>User One</strong>',
-				'<a class="filename tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
+				'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2Ffoo&scrollto=bar.file" title="in foo">bar.file</a>',
 			)),
 			array(array('user1', '/tmp/test'), array(0 => 'username', 1 => 'file'), true, true, array(
 				'<div class="avatar" data-user="user1"></div><strong>User One</strong>',
-				'<a class="filename tooltip" href="/index.php/apps/files?dir=%2Ftmp%2Ftest" title="in tmp">test</a>',
+				'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2Ftmp%2Ftest" title="in tmp">test</a>',
 			), '/test/files/tmp/test'),
 
 			// Disabled avatars #256
@@ -207,28 +207,28 @@ class ParameterHelperTest extends TestCase {
 			 * Federated Cloud ID
 			 */
 			array(array('username@localhost'), array(0 => 'federated_cloud_id'), false, true, array(
-				'<strong class="tooltip" title="username@localhost">username@localhost</strong>',
+				'<strong class="has-tooltip" title="username@localhost">username@localhost</strong>',
 			)),
 			array(array('username@localhost'), array(0 => 'federated_cloud_id'), false, false, array(
 				'username@localhost',
 			)),
 			array(array('username@localhost'), array(0 => 'federated_cloud_id'), true, true, array(
-				'<strong class="tooltip" title="username@localhost">username@…</strong>',
+				'<strong class="has-tooltip" title="username@localhost">username@…</strong>',
 			)),
 			array(array('username@localhost'), array(0 => 'federated_cloud_id'), true, false, array(
 				'username@…',
 			)),
 			array(array('username@localhost', 'username@localhost'), array(0 => 'federated_cloud_id', 1 => 'federated_cloud_id'), false, true, array(
-				'<strong class="tooltip" title="username@localhost">User @ Localhost</strong>',
-				'<strong class="tooltip" title="username@localhost">User @ Localhost</strong>',
+				'<strong class="has-tooltip" title="username@localhost">User @ Localhost</strong>',
+				'<strong class="has-tooltip" title="username@localhost">User @ Localhost</strong>',
 			), '', true, true),
 			array(array('username@localhost', 'username@localhost'), array(0 => 'federated_cloud_id', 1 => 'federated_cloud_id'), false, false, array(
 				'User @ Localhost',
 				'User @ Localhost',
 			), '', true, true),
 			array(array('username@localhost', 'username@localhost'), array(0 => 'federated_cloud_id', 1 => 'federated_cloud_id'), true, true, array(
-				'<strong class="tooltip" title="username@localhost">User @ Localhost</strong>',
-				'<strong class="tooltip" title="username@localhost">User @ Localhost</strong>',
+				'<strong class="has-tooltip" title="username@localhost">User @ Localhost</strong>',
+				'<strong class="has-tooltip" title="username@localhost">User @ Localhost</strong>',
 			), '', true, true),
 			array(array('username@localhost', 'username@localhost'), array(0 => 'federated_cloud_id', 1 => 'federated_cloud_id'), true, false, array(
 				'User @ Localhost',
@@ -308,14 +308,14 @@ class ParameterHelperTest extends TestCase {
 			array(
 				array('A/B.txt', 'C/D.txt', 'E/F.txt', 'G/H.txt', 'I/J.txt', 'K/L.txt', 'M/N.txt'), 'file', true, true, null,
 				(string) $en->n(
-					'%s and <strong class="tooltip" title="%s">%n more</strong>',
-					'%s and <strong class="tooltip" title="%s">%n more</strong>',
+					'%s and <strong class="has-tooltip" title="%s">%n more</strong>',
+					'%s and <strong class="has-tooltip" title="%s">%n more</strong>',
 					4,
 					[
 						implode((string) $en->t(', '), [
-							'<a class="filename tooltip" href="/index.php/apps/files?dir=%2FA&scrollto=B.txt" title="in A">B.txt</a>',
-							'<a class="filename tooltip" href="/index.php/apps/files?dir=%2FC&scrollto=D.txt" title="in C">D.txt</a>',
-							'<a class="filename tooltip" href="/index.php/apps/files?dir=%2FE&scrollto=F.txt" title="in E">F.txt</a>',
+							'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FA&scrollto=B.txt" title="in A">B.txt</a>',
+							'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FC&scrollto=D.txt" title="in C">D.txt</a>',
+							'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FE&scrollto=F.txt" title="in E">F.txt</a>',
 						]),
 						'G/H.txt, I/J.txt, K/L.txt, M/N.txt',
 					])
@@ -323,14 +323,14 @@ class ParameterHelperTest extends TestCase {
 			array(
 				array('A"><h1>/B.txt"><h1>', 'C"><h1>/D.txt"><h1>', 'E"><h1>/F.txt"><h1>', 'G"><h1>/H.txt"><h1>', 'I"><h1>/J.txt"><h1>', 'K"><h1>/L.txt"><h1>', 'M"><h1>/N.txt"><h1>'), 'file', true, true, null,
 				(string) $en->n(
-					'%s and <strong class="tooltip" title="%s">%n more</strong>',
-					'%s and <strong class="tooltip" title="%s">%n more</strong>',
+					'%s and <strong class="has-tooltip" title="%s">%n more</strong>',
+					'%s and <strong class="has-tooltip" title="%s">%n more</strong>',
 					4,
 					[
 						implode((string) $en->t(', '), [
-							'<a class="filename tooltip" href="/index.php/apps/files?dir=%2FA%22%3E%3Ch1%3E&scrollto=B.txt%22%3E%3Ch1%3E" title="in A&quot;&gt;&lt;h1&gt;">B.txt&quot;&gt;&lt;h1&gt;</a>',
-							'<a class="filename tooltip" href="/index.php/apps/files?dir=%2FC%22%3E%3Ch1%3E&scrollto=D.txt%22%3E%3Ch1%3E" title="in C&quot;&gt;&lt;h1&gt;">D.txt&quot;&gt;&lt;h1&gt;</a>',
-							'<a class="filename tooltip" href="/index.php/apps/files?dir=%2FE%22%3E%3Ch1%3E&scrollto=F.txt%22%3E%3Ch1%3E" title="in E&quot;&gt;&lt;h1&gt;">F.txt&quot;&gt;&lt;h1&gt;</a>',
+							'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FA%22%3E%3Ch1%3E&scrollto=B.txt%22%3E%3Ch1%3E" title="in A&quot;&gt;&lt;h1&gt;">B.txt&quot;&gt;&lt;h1&gt;</a>',
+							'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FC%22%3E%3Ch1%3E&scrollto=D.txt%22%3E%3Ch1%3E" title="in C&quot;&gt;&lt;h1&gt;">D.txt&quot;&gt;&lt;h1&gt;</a>',
+							'<a class="filename has-tooltip" href="/index.php/apps/files?dir=%2FE%22%3E%3Ch1%3E&scrollto=F.txt%22%3E%3Ch1%3E" title="in E&quot;&gt;&lt;h1&gt;">F.txt&quot;&gt;&lt;h1&gt;</a>',
 						]),
 						'G&quot;&gt;&lt;h1&gt;/H.txt&quot;&gt;&lt;h1&gt;, I&quot;&gt;&lt;h1&gt;/J.txt&quot;&gt;&lt;h1&gt;, K&quot;&gt;&lt;h1&gt;/L.txt&quot;&gt;&lt;h1&gt;, M&quot;&gt;&lt;h1&gt;/N.txt&quot;&gt;&lt;h1&gt;',
 					])


### PR DESCRIPTION
Broken by https://github.com/owncloud/core/pull/17075

### Steps to reproduce
1. Trigger an activity
2. Open activity stream

### Expected
1. Headline "Today"
2. The activity

### Actual
1. No headline
2. The activity

With this PR the headline is displayed again.

@MorrisJobke 