### PR TITLE
Remove deprecated global usage

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -47,8 +47,12 @@ class Application extends App {
 		 * Activity Services
 		 */
 		$container->registerService('ActivityData', function(IContainer $c) {
+			/** @var \OC\Server $server */
+			$server = $c->query('ServerContainer');
 			return new Data(
-				$c->query('ServerContainer')->query('ActivityManager')
+				$server->getActivityManager(),
+				$server->getDatabaseConnection(),
+				$server->getUserSession()
 			);
 		});
 

--- a/tests/apitest.php
+++ b/tests/apitest.php
@@ -76,7 +76,9 @@ class ApiTest extends TestCase {
 
 	protected function tearDown() {
 		$data = new Data(
-			$this->getMock('\OCP\Activity\IManager')
+			$this->getMock('\OCP\Activity\IManager'),
+			$this->getMock('\OCP\IDBConnection'),
+			$this->getMock('\OCP\IUserSession')
 		);
 
 		$this->deleteUser($data, 'activity-api-user1');

--- a/tests/datadeleteactivitestest.php
+++ b/tests/datadeleteactivitestest.php
@@ -57,7 +57,9 @@ class DataDeleteActivitiesTest extends TestCase {
 			));
 		}
 		$this->data = new Data(
-			$this->getMock('\OCP\Activity\IManager')
+			$this->getMock('\OCP\Activity\IManager'),
+			$this->getMock('\OCP\IDBConnection'),
+			$this->getMock('\OCP\IUserSession')
 		);
 	}
 

--- a/tests/datatest.php
+++ b/tests/datatest.php
@@ -26,6 +26,7 @@ use OC\ActivityManager;
 use OCA\Activity\Data;
 use OCA\Activity\Tests\Mock\Extension;
 use OCP\Activity\IExtension;
+use OCP\IUser;
 
 class DataTest extends TestCase {
 	/** @var \OCA\Activity\Data */
@@ -34,19 +35,33 @@ class DataTest extends TestCase {
 	/** @var \OCP\IL10N */
 	protected $activityLanguage;
 
+	/** @var ActivityManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $activityManager;
+
+	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	protected $session;
+
 	protected function setUp() {
 		parent::setUp();
 
 		$this->activityLanguage = $activityLanguage = \OCP\Util::getL10N('activity', 'en');
-		$activityManager = new ActivityManager(
+		$this->activityManager = new ActivityManager(
 			$this->getMock('OCP\IRequest'),
 			$this->getMock('OCP\IUserSession'),
 			$this->getMock('OCP\IConfig')
 		);
-		$activityManager->registerExtension(function() use ($activityLanguage) {
+		$this->session = $this->getMockBuilder('OCP\IUserSession')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->activityManager->registerExtension(function() use ($activityLanguage) {
 			return new Extension($activityLanguage, $this->getMock('\OCP\IURLGenerator'));
 		});
-		$this->data = new Data($activityManager);
+		$this->data = new Data(
+			$this->activityManager,
+			\OC::$server->getDatabaseConnection(),
+			$this->session
+		);
 	}
 
 	public function dataGetNotificationTypes() {
@@ -150,6 +165,103 @@ class DataTest extends TestCase {
 
 		$this->deleteTestActivities();
 		$this->restoreService('UserSession');
+	}
+
+	public function dataRead() {
+		$user = $this->getMockBuilder('\OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn('username');
+
+		return [
+			[null, 0, 10, 'all', '', null, [], null, null, [], '', []],
+			[$user, 0, 10, 'all', '', 'username', [], null, null, [], '', []],
+			[$user, 0, 10, 'all', 'test', 'test', [], null, null, [], '', []],
+			[$user, 0, 10, 'all', '', 'username', ['file_created'], false, null, [], ' AND `type` IN (?) AND `user` <> ?', ['username', 'file_created', 'username']],
+			[$user, 0, 10, 'all', '', 'username', ['file_created'], true, null, [], ' AND `type` IN (?)', ['username', 'file_created']],
+			[$user, 0, 10, 'by', '', 'username', ['file_created'], null, null, [], ' AND `type` IN (?) AND `user` <> ?', ['username', 'file_created', 'username']],
+			[$user, 0, 10, 'self', '', 'username', ['file_created'], null, null, [], ' AND `type` IN (?) AND `user` = ?', ['username', 'file_created', 'username']],
+			[$user, 0, 10, 'all', '', 'username', ['file_created'], true, 'OR `cond` = 1', null, ' AND `type` IN (?) OR `cond` = 1', ['username', 'file_created']],
+			[$user, 0, 10, 'all', '', 'username', ['file_created'], true, 'OR `cond` = ?', ['con1'], ' AND `type` IN (?) OR `cond` = ?', ['username', 'file_created', 'con1']],
+		];
+	}
+
+	/**
+	 * @dataProvider dataRead
+	 *
+	 * @param IUser $sessionUser
+	 * @param int $start
+	 * @param int $count
+	 * @param string $filter
+	 * @param string $user
+	 * @param string $expectedUser
+	 * @param array $notificationTypes
+	 * @param bool $selfSetting
+	 * @param array $conditions
+	 * @param array $params
+	 * @param string $limitActivities
+	 * @param array $parameters
+	 */
+	public function testRead($sessionUser, $start, $count, $filter, $user, $expectedUser, $notificationTypes, $selfSetting, $conditions, $params, $limitActivities, $parameters) {
+
+		/** @var \OCA\Activity\GroupHelper|\PHPUnit_Framework_MockObject_MockObject $groupHelper */
+		$groupHelper = $this->getMockBuilder('OCA\Activity\GroupHelper')
+			->disableOriginalConstructor()
+			->getMock();
+		$groupHelper->expects(($expectedUser === null) ? $this->never() : $this->once())
+			->method('setUser')
+			->with($expectedUser);
+
+		/** @var \OCA\Activity\UserSettings|\PHPUnit_Framework_MockObject_MockObject $settings */
+		$settings = $this->getMockBuilder('OCA\Activity\UserSettings')
+			->disableOriginalConstructor()
+			->getMock();
+		$settings->expects(($expectedUser === null) ? $this->never() : $this->once())
+			->method('getNotificationTypes')
+			->with($expectedUser, 'stream')
+			->willReturn(['settings']);
+		$settings->expects(($selfSetting === null) ? $this->never() : $this->any())
+			->method('getUserSetting')
+			->with($expectedUser, 'setting', 'self')
+			->willReturn($selfSetting);
+
+		/** @var ActivityManager|\PHPUnit_Framework_MockObject_MockObject $activityManager */
+		$activityManager = $this->getMockBuilder('OCP\Activity\IManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$activityManager->expects($this->any())
+			->method('filterNotificationTypes')
+			->with(['settings'], $filter)
+			->willReturn($notificationTypes);
+		$activityManager->expects($this->any())
+			->method('getQueryForFilter')
+			->with($filter)
+			->willReturn([$conditions, $params]);
+
+		/** @var \OCA\Activity\Data|\PHPUnit_Framework_MockObject_MockObject $data */
+		$data = $this->getMockBuilder('OCA\Activity\Data')
+			->setConstructorArgs([
+				$activityManager,
+				\OC::$server->getDatabaseConnection(),
+				$this->session
+			])
+			->setMethods(['getActivities'])
+			->getMock();
+		$data->expects($this->any())
+			->method('getActivities')
+			->with($count, $start, $limitActivities, $parameters, $groupHelper)
+			->willReturn([]);
+
+		$this->session->expects($this->any())
+			->method('getUser')
+			->willReturn($sessionUser);
+
+		$this->assertEquals([], $data->read(
+			$groupHelper, $settings,
+			$start, $count, $filter, $user
+		));
 	}
 
 	/**

--- a/tests/hooksdeleteusertest.php
+++ b/tests/hooksdeleteusertest.php
@@ -68,7 +68,9 @@ class HooksDeleteUserTest extends TestCase {
 
 	protected function tearDown() {
 		$data = new Data(
-			$this->getMock('\OCP\Activity\IManager')
+			$this->getMock('\OCP\Activity\IManager'),
+			$this->getMock('\OCP\IDBConnection'),
+			$this->getMock('\OCP\IUserSession')
 		);
 		$data->deleteActivities(array(
 			'type' => 'test',

--- a/tests/usersettingstest.php
+++ b/tests/usersettingstest.php
@@ -47,7 +47,11 @@ class UserSettingsTest extends TestCase {
 			return new Extension($activityLanguage, $this->getMock('\OCP\IURLGenerator'));
 		});
 		$this->config = $this->getMock('OCP\IConfig');
-		$this->userSettings = new UserSettings($activityManager, $this->config, new Data($activityManager));
+		$this->userSettings = new UserSettings($activityManager, $this->config, new Data(
+			$activityManager,
+			$this->getMock('\OCP\IDBConnection'),
+			$this->getMock('\OCP\IUserSession')
+		));
 	}
 
 	protected function tearDown() {


### PR DESCRIPTION
Replaces the `\OCP\DB` and `\OCP\User` usages with the new non-static version
And finally tests for `read()`
![code_coverage_for_home_nickv_owncloud_master_core_repos_activity_lib_data php_-_2015-08-14_12 43 51](https://cloud.githubusercontent.com/assets/213943/9272393/2d75534a-4282-11e5-8039-d656dec011ee.png)
