### PR TITLE
Add an index to cover the expire SQL query

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -104,6 +104,14 @@
 			</field>
 
 			<index>
+				<name>activity_time</name>
+				<field>
+					<name>timestamp</name>
+					<sorting>descending</sorting>
+				</field>
+			</index>
+
+			<index>
 				<name>activity_user_time</name>
 				<field>
 					<name>affecteduser</name>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek, Joas Schilling</author>
 	<shipped>true</shipped>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<default_enable/>
 	<types>
 		<filesystem/>


### PR DESCRIPTION
@karlitschek we could backport this easily.
The issue was reported for 8.1.3
Should we backport it? And if yes, only to 8.2 or also 8.1?

Fix #423 

@scolebrook 