### PR TITLE
fix message style in activity view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@
 	overflow: hidden;
 }
 .activitymessage {
-	font-size:0.8em;
+	margin-left: 25px;
 	color:#666;
 	text-overflow: ellipsis;
 	overflow: hidden;


### PR DESCRIPTION
Make it normal size and left-align it with the avatar, so that it’s like in the sidebar in Files.

Please review @nickvergessen @owncloud/designers 

I’d also like to backport this to stable9 since this looks like a bad design glitch. @karlitschek 