### PR TITLE
[9.0] Store the preferences as integers for postgres

### DIFF
--- a/controller/settings.php
+++ b/controller/settings.php
@@ -106,13 +106,13 @@ class Settings extends Controller {
 			$this->config->setUserValue(
 				$this->user, 'activity',
 				'notify_email_' . $type,
-				$this->request->getParam($type . '_email', false)
+				(int) $this->request->getParam($type . '_email', false)
 			);
 
 			$this->config->setUserValue(
 				$this->user, 'activity',
 				'notify_stream_' . $type,
-				$this->request->getParam($type . '_stream', false)
+				(int) $this->request->getParam($type . '_stream', false)
 			);
 		}
 
@@ -131,12 +131,12 @@ class Settings extends Controller {
 		$this->config->setUserValue(
 			$this->user, 'activity',
 			'notify_setting_self',
-			$notify_setting_self
+			(int) $notify_setting_self
 		);
 		$this->config->setUserValue(
 			$this->user, 'activity',
 			'notify_setting_selfemail',
-			$notify_setting_selfemail
+			(int) $notify_setting_selfemail
 		);
 
 		return new DataResponse(array(

--- a/lib/usersettings.php
+++ b/lib/usersettings.php
@@ -63,15 +63,25 @@ class UserSettings {
 	 * @param string $user
 	 * @param string $method Should be one of 'stream', 'email' or 'setting'
 	 * @param string $type One of the activity types, 'batchtime' or 'self'
-	 * @return mixed
+	 * @return bool|int
 	 */
 	public function getUserSetting($user, $method, $type) {
-		return $this->config->getUserValue(
-			$user,
-			'activity',
-			'notify_' . $method . '_' . $type,
-			$this->getDefaultSetting($method, $type)
-		);
+		$defaultSetting = $this->getDefaultSetting($method, $type);
+		if (is_bool($defaultSetting)) {
+			return (bool) $this->config->getUserValue(
+				$user,
+				'activity',
+				'notify_' . $method . '_' . $type,
+				$defaultSetting
+			);
+		} else {
+			return (int) $this->config->getUserValue(
+				$user,
+				'activity',
+				'notify_' . $method . '_' . $type,
+				$defaultSetting
+			);
+		}
 	}
 
 	/**

--- a/tests/usersettingstest.php
+++ b/tests/usersettingstest.php
@@ -98,10 +98,10 @@ class UserSettingsTest extends TestCase {
 			->method('getUserValue')
 			->with($this->anything(), 'activity', $this->stringStartsWith('notify_'), $this->anything())
 			->willReturnMap([
-				['test1', 'activity', 'notify_stream_type1', true, true],
-				['test1', 'activity', 'notify_stream_type2', true, false],
-				['noPreferences', 'activity', 'notify_email_type1', false, false],
-				['noPreferences', 'activity', 'notify_email_type2', true, true],
+				['test1', 'activity', 'notify_stream_type1', true, 1],
+				['test1', 'activity', 'notify_stream_type2', true, 0],
+				['noPreferences', 'activity', 'notify_email_type1', false, 0],
+				['noPreferences', 'activity', 'notify_email_type2', true, 1],
 			]);
 
 		$this->assertEquals($expected, $this->userSettings->getNotificationTypes($user, $method));
@@ -110,10 +110,10 @@ class UserSettingsTest extends TestCase {
 	public function filterUsersBySettingData() {
 		return array(
 			array(array(), 'stream', 'type1', array()),
-			array(array('test', 'test1', 'test2', 'test3', 'test4'), 'stream', 'type3', array('test1' => true, 'test4' => true)),
-			array(array('test', 'test1', 'test2', 'test3', 'test4', 'test5'), 'email', 'type3', array('test1' => '1', 'test4' => '4', 'test5' => true)),
-			array(array('test', 'test6'), 'stream', 'type1', array('test' => true, 'test6' => true)),
-			array(array('test', 'test6'), 'stream', 'type4', array('test6' => true)),
+			array(array('test', 'test1', 'test2', 'test3', 'test4'), 'stream', 'type3', array('test1' => 1, 'test4' => 1)),
+			array(array('test', 'test1', 'test2', 'test3', 'test4', 'test5'), 'email', 'type3', array('test1' => '1', 'test4' => '4', 'test5' => 1)),
+			array(array('test', 'test6'), 'stream', 'type1', array('test' => 1, 'test6' => 1)),
+			array(array('test', 'test6'), 'stream', 'type4', array('test6' => 1)),
 			array(array('test6'), 'email', 'type2', array('test6' => '2700')),
 			array(array('test', 'test6'), 'email', 'type2', array('test' => '3600', 'test6' => '2700')),
 			array(array('test', 'test6'), 'email', 'type1', array('test6' => '2700')),


### PR DESCRIPTION
Backport of #499 