### PR TITLE
fix 529: Avatar image in activity tab broken for "remote user"

### DIFF
--- a/js/activitytabview.js
+++ b/js/activitytabview.js
@@ -166,7 +166,11 @@
 		_postRenderItem: function($el) {
 			$el.find('.avatar').each(function() {
 				var element = $(this);
-				element.avatar(element.data('user'), 28);
+				if (element.data('user-display-name')) {
+					element.avatar(element.data('user'), 28, undefined, false, undefined, element.data('user-display-name'));
+				} else if (element.data('user')) {
+					element.avatar(element.data('user'), 28);
+				}
 			});
 			$el.find('.has-tooltip').tooltip({
 				placement: 'bottom'


### PR DESCRIPTION
Fix #529: Use (first character of) display name for avatar in activity tab if username is unavailable same as main in view.