### PR TITLE
Revert "fix 529: Avatar image in activity tab broken for "remote user""

### DIFF
--- a/js/activitytabview.js
+++ b/js/activitytabview.js
@@ -166,11 +166,7 @@
 		_postRenderItem: function($el) {
 			$el.find('.avatar').each(function() {
 				var element = $(this);
-				if (element.data('user-display-name')) {
-					element.avatar(element.data('user'), 28, undefined, false, undefined, element.data('user-display-name'));
-				} else if (element.data('user')) {
-					element.avatar(element.data('user'), 28);
-				}
+				element.avatar(element.data('user'), 28);
 			});
 			$el.find('.has-tooltip').tooltip({
 				placement: 'bottom'


### PR DESCRIPTION
Reverts non-critical fix that was merged by mistake during the code freeze.

@DeepDiver1975 please approve.

I'll resend a PR so we can get the fix into 9.1.4