### PR TITLE
Activity rename

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -292,6 +292,7 @@ class Application extends App {
 		Util::connectHook('OC_Filesystem', 'post_create', 'OCA\Activity\FilesHooksStatic', 'fileCreate');
 		Util::connectHook('OC_Filesystem', 'post_update', 'OCA\Activity\FilesHooksStatic', 'fileUpdate');
 		Util::connectHook('OC_Filesystem', 'delete', 'OCA\Activity\FilesHooksStatic', 'fileDelete');
+		Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Activity\FilesHooksStatic', 'fileRename');
 		Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', 'OCA\Activity\FilesHooksStatic', 'fileRestore');
 		Util::connectHook('OCP\Share', 'post_shared', 'OCA\Activity\FilesHooksStatic', 'share');
 		Util::connectHook('OCP\Share', 'pre_unshare', 'OCA\Activity\FilesHooksStatic', 'unShare');

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -292,6 +292,7 @@ class Application extends App {
 		Util::connectHook('OC_Filesystem', 'post_create', 'OCA\Activity\FilesHooksStatic', 'fileCreate');
 		Util::connectHook('OC_Filesystem', 'post_update', 'OCA\Activity\FilesHooksStatic', 'fileUpdate');
 		Util::connectHook('OC_Filesystem', 'delete', 'OCA\Activity\FilesHooksStatic', 'fileDelete');
+		Util::connectHook('OC_Filesystem', 'rename', 'OCA\Activity\FilesHooksStatic', 'fileBeforeRename');
 		Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Activity\FilesHooksStatic', 'fileRename');
 		Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', 'OCA\Activity\FilesHooksStatic', 'fileRestore');
 		Util::connectHook('OCP\Share', 'post_shared', 'OCA\Activity\FilesHooksStatic', 'share');

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -222,6 +222,9 @@ class Data {
 					'file_created',
 					'file_changed',
 					'file_deleted',
+					'file_renamed',
+					'file_movedin',
+					'file_movedout',
 					'file_restored',
 				], IQueryBuilder::PARAM_STR_ARRAY))
 			));
@@ -234,6 +237,9 @@ class Data {
 						'file_created',
 						'file_changed',
 						'file_deleted',
+						'file_renamed',
+						'file_movedin',
+						'file_movedout',
 						'file_restored',
 					], IQueryBuilder::PARAM_STR_ARRAY))
 				));

--- a/lib/Extension/Files.php
+++ b/lib/Extension/Files.php
@@ -27,4 +27,6 @@ class Files {
 	const TYPE_SHARE_DELETED = 'file_deleted';
 	const TYPE_SHARE_RENAMED = 'file_renamed';
 	const TYPE_SHARE_RESTORED = 'file_restored';
+	const TYPE_SHARE_MOVEDIN = 'file_movedin';
+	const TYPE_SHARE_MOVEDOUT = 'file_movedout';
 }

--- a/lib/Extension/Files.php
+++ b/lib/Extension/Files.php
@@ -25,5 +25,6 @@ class Files {
 	const TYPE_SHARE_CREATED = 'file_created';
 	const TYPE_SHARE_CHANGED = 'file_changed';
 	const TYPE_SHARE_DELETED = 'file_deleted';
+	const TYPE_SHARE_RENAMED = 'file_renamed';
 	const TYPE_SHARE_RESTORED = 'file_restored';
 }

--- a/lib/Extension/Files_Sharing.php
+++ b/lib/Extension/Files_Sharing.php
@@ -23,4 +23,6 @@ namespace OCA\Activity\Extension;
 
 class Files_Sharing {
 	const TYPE_SHARED = 'shared';
+	const TYPE_SHARE_MOVEIN = 'share_movein';
+	const TYPE_SHARE_MOVEOUT = 'share_moveout';
 }

--- a/lib/Extension/Files_Sharing.php
+++ b/lib/Extension/Files_Sharing.php
@@ -23,6 +23,4 @@ namespace OCA\Activity\Extension;
 
 class Files_Sharing {
 	const TYPE_SHARED = 'shared';
-	const TYPE_SHARE_MOVEIN = 'share_movein';
-	const TYPE_SHARE_MOVEOUT = 'share_moveout';
 }

--- a/lib/FilesHooksStatic.php
+++ b/lib/FilesHooksStatic.php
@@ -62,6 +62,17 @@ class FilesHooksStatic {
 	}
 
 	/**
+	 * Store the rename hook events
+	 * @param array $params The hook params
+	 */
+	public static function fileRename($params) {
+		self::getHooks()->fileRename(
+			$params['oldpath'],
+			$params['newpath']
+		);
+	}
+
+	/**
 	 * Store the restore hook events
 	 * @param array $params The hook params
 	 */

--- a/lib/FilesHooksStatic.php
+++ b/lib/FilesHooksStatic.php
@@ -30,11 +30,18 @@ use OCP\Util;
 class FilesHooksStatic {
 
 	/**
+	 * @var Appinfo\Application
+	 */
+	private static $app = null;
+
+	/**
 	 * @return FilesHooks
 	 */
 	static protected function getHooks() {
-		$app = new AppInfo\Application();
-		return $app->getContainer()->query('Hooks');
+		if (self::$app === null) {
+			self::$app = new AppInfo\Application();
+		}
+		return self::$app->getContainer()->query('Hooks');
 	}
 
 	/**
@@ -59,6 +66,17 @@ class FilesHooksStatic {
 	 */
 	public static function fileDelete($params) {
 		self::getHooks()->fileDelete($params['path']);
+	}
+
+	/**
+	 * Store the preRename hook events
+	 * @param array $params The hook params
+	 */
+	public static function fileBeforeRename($params) {
+		self::getHooks()->fileBeforeRename(
+			$params['oldpath'],
+			$params['newpath']
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/owncloud/activity/issues/375

TODOs:
- [x] create activity for rename
- [x] create activity for move in
- [x] create activity for move out
- [ ] properly format activity for main activity log: "U move file X to Y" with full paths
- [ ] format/filter activity for the sidebar activity log: "U renamed this file from X to Y" with basename only
- [ ] distinguish rename/move in display ?
- [x] add activity types for email/stream filter (personal page + code)
- [ ] check handling when renaming mount points

- [ ] add unit tests