### PR TITLE
[stable9.1] Translate the methodname in the table header

### DIFF
--- a/templates/personal.php
+++ b/templates/personal.php
@@ -17,7 +17,7 @@ style('activity', 'settings');
 			<tr>
 				<?php foreach ($_['methods'] as $method => $methodName): ?>
 				<th class="small activity_select_group" data-select-group="<?php p($method) ?>">
-					<?php p($methodName); ?>
+					<?php p($l->t($methodName)); ?>
 				</th>
 				<?php endforeach; ?>
 				<th><span id="activity_notifications_msg" class="msg"></span></th>


### PR DESCRIPTION
We are using this app for our owncloud instance and found out that the method name in the table header is not translated. This patch fixes this bug.
Issue: https://github.com/owncloud/activity/issues/567