### PR TITLE
Fallback to old tests/lib if tests/unit does not exist

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,7 +27,7 @@ require_once __DIR__.'/../../../lib/base.php';
 
 $unitTestLocation = '/tests/unit/';
 
-if (!file_exists(OC::$SERVERROOT . $unitTestLocation)) {
+if (!is_dir(OC::$SERVERROOT . $unitTestLocation)) {
 	$unitTestLocation = '/tests/lib/';
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,13 +23,13 @@ if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
+require_once __DIR__.'/../../../lib/base.php';
+
 $unitTestLocation = '/tests/unit/';
 
-if (!file_exists(\OC::$SERVERROOT . $unitTestLocation)) {
+if (!file_exists(OC::$SERVERROOT . $unitTestLocation)) {
 	$unitTestLocation = '/tests/lib/';
 }
-
-require_once __DIR__.'/../../../lib/base.php';
 
 \OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . $unitTestLocation, true);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,9 +23,15 @@ if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
+$unitTestLocation = '/tests/unit/';
+
+if (!file_exists(OC::$SERVERROOT . $unitTestLocation)) {
+	$unitTestLocation = '/tests/lib/';
+}
+
 require_once __DIR__.'/../../../lib/base.php';
 
-\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);
+\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . $unitTestLocation, true);
 
 // Fix for "Autoload path not allowed: .../tests/lib/testcase.php"
 \OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,7 +25,7 @@ if (!defined('PHPUNIT_RUN')) {
 
 $unitTestLocation = '/tests/unit/';
 
-if (!file_exists(OC::$SERVERROOT . $unitTestLocation)) {
+if (!file_exists(\OC::$SERVERROOT . $unitTestLocation)) {
 	$unitTestLocation = '/tests/lib/';
 }
 


### PR DESCRIPTION
This could be code for apps to automagically choose the folder for the core unit test shared code.