### PR TITLE
Release Changes for master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ nbproject
 /tests/clover.xml
 /tests/js/node_modules
 /vendor/
+/build/

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ COMPOSER_BIN=$(build_dir)/composer.phar
 
 # internal aliases
 composer_deps=
-composer_dev_deps=
+composer_dev_deps=vendor
 nodejs_deps=
 bower_deps=
 
@@ -59,7 +59,7 @@ $(COMPOSER_BIN):
 	cd $(build_dir) && curl -sS https://getcomposer.org/installer | php
 
 #
-# ownCloud ldap PHP dependencies
+# PHP dependencies
 #
 $(composer_deps): $(COMPOSER_BIN) composer.json composer.lock
 	php $(COMPOSER_BIN) install --no-dev
@@ -78,7 +78,7 @@ update-composer: $(COMPOSER_BIN)
 	php $(COMPOSER_BIN) install --prefer-dist
 
 #
-## Node JS dependencies for tools
+## Node dependencies
 #
 $(nodejs_deps): package.json
 	$(NPM) install --prefix $(NODE_PREFIX) && touch $@

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ endif
 	tar -czf $(dist_dir)/$(app_name).tar.gz -C $(dist_dir) $(app_name)
 
 .PHONY: dist
-dist: $(dist_dir)/$(app_name)
+dist: clean-dist $(dist_dir)/$(app_name)
 
 .PHONY: clean-dist
 clean-dist:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean: clean-composer-deps clean-dist clean-build
 # Basic required tools
 #
 $(COMPOSER_BIN):
-	mkdir $(build_dir)
+	mkdir -p $(build_dir)
 	cd $(build_dir) && curl -sS https://getcomposer.org/installer | php
 
 #

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
 
 app_name=$(notdir $(CURDIR))
 doc_files=README.md CHANGELOG.md CONTRIBUTING.md
-src_dirs=appinfo css img js l10n lib templates vendor
+src_dirs=appinfo css img js l10n lib templates
 all_src=$(src_dirs) $(doc_files)
 build_dir=$(CURDIR)/build
 dist_dir=$(build_dir)/dist
@@ -92,15 +92,9 @@ $(bower_deps): $(BOWER)
 #
 # dist
 #
-
 $(dist_dir)/$(app_name): $(composer_deps) $(bower_deps)
 	rm -Rf $@; mkdir -p $@
 	cp -R $(all_src) $@
-	find $@/vendor -type d -iname Test? -print | xargs rm -Rf
-	find $@/vendor -name travis -print | xargs rm -Rf
-	find $@/vendor -name doc -print | xargs rm -Rf
-	find $@/vendor -iname \*.sh -delete
-	find $@/vendor -iname \*.exe -delete
 
 ifdef CAN_SIGN
 	$(sign) --path="$(dist_dir)/$(app_name)"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build_dir=$(CURDIR)/build
 dist_dir=$(build_dir)/dist
 COMPOSER_BIN=$(build_dir)/composer.phar
 
-# internal aliases
+# dependency folders (leave empty if not required)
 composer_deps=
 composer_dev_deps=vendor
 nodejs_deps=
@@ -48,8 +48,7 @@ endif
 all: $(composer_dev_deps) $(bower_deps)
 
 .PHONY: clean
-clean: clean-composer-deps clean-dist clean-build
-
+clean: clean-deps clean-dist clean-build
 
 #
 # Basic required tools
@@ -70,7 +69,7 @@ $(composer_dev_deps): $(COMPOSER_BIN) composer.json composer.lock
 .PHONY: clean-composer-deps
 clean-composer-deps:
 	rm -f $(COMPOSER_BIN)
-	rm -Rf $(composer_deps)
+	rm -Rf $(composer_deps) $(composer_dev_deps)
 
 .PHONY: update-composer
 update-composer: $(COMPOSER_BIN)
@@ -113,3 +112,8 @@ clean-dist:
 .PHONY: clean-build
 clean-build:
 	rm -Rf $(build_dir)
+
+.PHONY: clean-deps
+clean-deps: clean-composer-deps
+	rm -Rf $(nodejs_deps) $(bower_deps)
+

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ else
 	@echo $(sign_skip_msg)
 endif
 	tar -czf $(dist_dir)/$(app_name).tar.gz -C $(dist_dir) $(app_name)
+	tar -cjf $(dist_dir)/$(app_name).tar.bz2 -C $(dist_dir) $(app_name)
 
 .PHONY: dist
 dist: clean-dist $(dist_dir)/$(app_name)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,6 +2,7 @@
 <info>
   <id>activity</id>
   <name>Activity</name>
+  <summary>Activity feed with latest changes of your files.</summary>
   <description>
 		This application enables users to view actions related to their files in ownCloud.
 		Once enabled, users will see a new icon &#x201C;Activity&#x201D; in their apps menu.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 	</description>
   <licence>AGPL</licence>
   <author>Frank Karlitschek, Joas Schilling</author>
-  <version>2.3.6-beta1</version>
+  <version>2.3.6</version>
   <default_enable/>
   <types>
     <filesystem/>


### PR DESCRIPTION
- clean gitignore
- better Makefile
- bump version to 2.3.6
- add summary to info.xml

# General Makefile thoughts

Goal: unified Makefile.
This Makefile used for "all" apps, ongoing work on having one Makefile for all.
Still small differences.
Unified the structure of Makefile and the build output: 
- `/build/dist/appname` folder with app
- `/build/dist/appname.tar.gz` tarball

Open topics (not "activity app" specific):
- occ command, run with php -f or not? I think we should not prepend a `php -f `. Objections?
- vendor cleanup: needs more logic to skip cleanup, if no vendor folder available
- deprecate Bower in all apps, at least install bower via npm if needed

