### PR TITLE
Check to see if avatar method is available in _postRenderItem()

### DIFF
--- a/js/activitytabview.js
+++ b/js/activitytabview.js
@@ -193,10 +193,12 @@
 		_postRenderItem: function($el) {
 			$el.find('.avatar').each(function() {
 				var element = $(this);
-				if (element.data('user-display-name')) {
-					element.avatar(element.data('user'), 28, undefined, false, undefined, element.data('user-display-name'));
-				} else if (element.data('user')) {
-					element.avatar(element.data('user'), 28);
+				if (typeof element.avatar === 'function') {
+					if (element.data('user-display-name')) {
+						element.avatar(element.data('user'), 28, undefined, false, undefined, element.data('user-display-name'));
+					} else if (element.data('user')) {
+						element.avatar(element.data('user'), 28);
+					}
 				}
 			});
 			$el.find('.has-tooltip').tooltip({


### PR DESCRIPTION
We are running ownCloud 10.0.3 with `'enable_avatars' => false` in the config.php and this issue does not occur if I change that setting to true.

When trying to list the activity of a file or folder in the sidebar, we get the following exception.
```Uncaught TypeError: element.avatar is not a function``` which stops the activity list from loading and only shows a blank list.

This pull request just adds in a check to make sure the avatar method exists before trying to run it.
