### PR TITLE
Chunk deleting of rows from the activity table

### DIFF
--- a/lib/Data.php
+++ b/lib/Data.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Activity;
 
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use OCA\Activity\Exception\InvalidFilterException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IExtension;
@@ -406,8 +407,24 @@ class Data {
 			$sqlWhere = ' WHERE ' . implode(' AND ', $sqlWhereList);
 		}
 
-		$query = $this->connection->prepare(
-			'DELETE FROM `*PREFIX*activity`' . $sqlWhere);
-		$query->execute($sqlParameters);
+		// Add galera safe delete chunking if using mysql
+		// Stops us hitting wsrep_max_ws_rows when large row counts are deleted
+		if($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+			// Then use chunked delete
+			$max = 100000;
+			$query = $this->connection->prepare(
+				'DELETE FROM `*PREFIX*activity`' . $sqlWhere . " LIMIT " . $max);
+			do {
+				$query->execute($sqlParameters);
+				$deleted = $query->rowCount();
+			} while($deleted === $max);
+		} else {
+			// Dont use chunked delete - let the DB handle the large row count natively
+			$query = $this->connection->prepare(
+				'DELETE FROM `*PREFIX*activity`' . $sqlWhere);
+			$query->execute($sqlParameters);
+		}
+
+
 	}
 }

--- a/tests/DataDeleteActivitiesTest.php
+++ b/tests/DataDeleteActivitiesTest.php
@@ -22,6 +22,8 @@
 namespace OCA\Activity\Tests;
 
 use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OCA\Activity\Data;
 use OCP\Activity\IExtension;
 
@@ -122,4 +124,45 @@ class DataDeleteActivitiesTest extends TestCase {
 
 		$this->assertEquals($expected, $users);
 	}
+
+	public function testChunkingDeleteNotUsedWhenNotOnMysql() {
+		$ttl = (60 * 60 * 24 * max(1, 365));
+		$timelimit = time() - $ttl;
+		$activityManager = $this->createMock(\OCP\Activity\IManager::class);
+		$connection = $this->createMock(\OCP\IDBConnection::class);
+		$platform = $this->createMock(SqlitePlatform::class);
+		$connection->expects($this->once())->method('getDatabasePlatform')->willReturn($platform);
+
+		$statement = $this->createMock(Statement::class);
+		// Wont chunk
+		$statement->expects($this->exactly(0))->method('rowCount')->willReturnOnConsecutiveCalls(100000, 50);
+		$connection->expects($this->once())->method('prepare')->willReturn($statement);
+
+		$userSession = $this->createMock(\OCP\IUserSession::class);
+		$data = new Data($activityManager, $connection, $userSession);
+		$data->deleteActivities(array(
+			'timestamp' => array($timelimit, '<'),
+		));
+	}
+
+	public function testDeleteActivitiesIsChunkedOnMysql() {
+		$ttl = (60 * 60 * 24 * max(1, 365));
+		$timelimit = time() - $ttl;
+		$activityManager = $this->createMock(\OCP\Activity\IManager::class);
+		$connection = $this->createMock(\OCP\IDBConnection::class);
+		$platform = $this->createMock(MySqlPlatform::class);
+		$connection->expects($this->once())->method('getDatabasePlatform')->willReturn($platform);
+
+		$statement = $this->createMock(Statement::class);
+		// Will chunk
+		$statement->expects($this->exactly(2))->method('rowCount')->willReturnOnConsecutiveCalls(100000, 50);
+		$connection->expects($this->once())->method('prepare')->willReturn($statement);
+
+		$userSession = $this->createMock(\OCP\IUserSession::class);
+		$data = new Data($activityManager, $connection, $userSession);
+		$data->deleteActivities(array(
+			'timestamp' => array($timelimit, '<'),
+		));
+	}
+
 }


### PR DESCRIPTION
Fixes for clustered environments, which have a limit on rows and size of data affected by each transaction due to replication concerns.