### PR TITLE
Prepare for jquery 2 update

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -257,7 +257,7 @@ $(function(){
 				}
 			});
 
-			$element.find('.activity-more-link').click(function() {
+			$element.find('.activity-more-link').on('click', function() {
 				var $moreElement = $(this),
 					activityId = $moreElement.closest('.box').data('activity-id'),
 					$subject = $moreElement.closest('.activitysubject');

--- a/js/settings.js
+++ b/js/settings.js
@@ -13,7 +13,7 @@ $(document).ready(function() {
 
 	$activityNotifications.find('select').change(saveSettings);
 
-	$activityNotifications.find('.activity_select_group').click(function() {
+	$activityNotifications.find('.activity_select_group').on('click', function() {
 		var $selectGroup = '#activity_notifications .' + $(this).attr('data-select-group');
 		var $filteredBoxes = $($selectGroup).not(':disabled');
 		var $checkedBoxes = $filteredBoxes.filter(':checked').length;


### PR DESCRIPTION
Replace .click() with .on('click')

Fixes https://github.com/owncloud/activity/issues/637

To test:
- [x] clicking on "more activites" link still works (pagination)
- [x] pagination still works (`before()` call will insert ittems)
- [x] clicking on column header in checkbox settings still works
