### PR TITLE
Add new mail footers to template files.

### DIFF
--- a/templates/email.notification.php
+++ b/templates/email.notification.php
@@ -20,3 +20,4 @@ if ($_['skippedCount']) {
 	p("\n");
 }
 p("\n");
+print_unescaped($this->inc('plain.mail.footer', ['app' => 'core']));

--- a/templates/html.notification.php
+++ b/templates/html.notification.php
@@ -45,19 +45,14 @@ $l = $_['overwriteL10N'];
 						</ul>
 					</td>
 				</tr>
-				<tr><td colspan="2">&nbsp;</td></tr>
-				<tr>
-					<td width="20px">&nbsp;</td>
-					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">--<br>
-						<?php p($theme->getName()); ?> -
-						<?php p($theme->getSlogan()); ?>
-						<br><a href="<?php p($theme->getBaseUrl()); ?>">
-							<?php p($theme->getBaseUrl());?>
-						</a>
-					</td>
-				</tr>
 				<tr>
 					<td colspan="2">&nbsp;</td>
+				</tr>
+				<tr>
+					<td width="20px">&nbsp;</td>
+					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
+						<?php print_unescaped($this->inc('html.mail.footer', ['app' => 'core'])); ?>
+					</td>
 				</tr>
 			</table>
 		</td></tr>


### PR DESCRIPTION
Fixes owncloud/enterprise#2788

### Expected behaviour
Mails from the activity app should contain the new mail footer with "imprint" and "privacy policy" links.

Html Footer
```php
<?php print_unescaped($this->inc('html.mail.footer', ['app' => 'core'])); ?>
```
Plain Text Footer
```
<?php print_unescaped($this->inc('plain.mail.footer', ['app' => 'core'])); ?>
```
## What happens instead
The footer is missing.

Activity app didn't follow up with this change.