### PR TITLE
Add missing migrations for longtext and indices

### DIFF
--- a/appinfo/Migrations/Version20181019151118.php
+++ b/appinfo/Migrations/Version20181019151118.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\activity\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Adds migrations that were missing when running update.
+ *
+ * - set type to "longtext" for "subjectparams" and "messageparams" by increasing length
+ *
+ */
+class Version20181019151118 implements ISchemaMigration {
+	/**
+	 * @param Schema $schema
+	 * @param array $options
+	 */
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		
+		$activityTable = $schema->getTable("{$prefix}activity");
+
+		if (!$activityTable->hasIndex('activity_time')) {
+			$activityTable->addIndex(
+				['timestamp'],
+				'activity_time'
+			);
+		}
+
+		if (!$activityTable->hasIndex('activity_object')) {
+			$activityTable->addIndex(
+				['object_type', 'object_id'],
+				'activity_object'
+			);
+		}
+	}
+}

--- a/appinfo/Migrations/Version20181022150134.php
+++ b/appinfo/Migrations/Version20181022150134.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\activity\Migrations;
+
+use OCP\Migration\ISqlMigration;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use OCP\IDBConnection;
+
+/**
+ * Adds migrations that were missing when running update.
+ *
+ * - set type to "longtext" for "subjectparams" and "messageparams" by increasing length
+ *
+ */
+class Version20181022150134 implements ISqlMigration {
+
+	/**
+	 * @param Schema $schema
+	 * @param array $options
+	 */
+	public function sql(IDBConnection $connection) {
+		$platform = $connection->getDatabasePlatform();
+		$tableName = "*PREFIX*activity";
+		$tableName = $connection->getDatabasePlatform()->quoteIdentifier($tableName);
+		
+		if ($platform instanceof MySqlPlatform) {
+			$sqls = [
+				"ALTER TABLE $tableName MODIFY COLUMN `subjectparams` LONGTEXT NOT NULL",
+				"ALTER TABLE $tableName MODIFY COLUMN `messageparams` LONGTEXT NULL",
+			];
+		} else {
+			$sqls = [];
+		}
+
+		return $sqls;
+	}
+}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@ Never again miss an important event related to content in ownCloud and always be
   </description>
   <licence>AGPL</licence>
   <author>Frank Karlitschek, Joas Schilling, Tom Needham, Thomas Müller, Vincent Petry</author>
-  <version>2.3.8</version>
+  <version>2.4.0</version>
   <default_enable/>
   <types>
     <filesystem/>


### PR DESCRIPTION
- set type to "longtext" for "subjectparams" and "messageparams" by increasing length
- add index "activity_time" on column "timestamp"
- add index "activity_object" on columns "object_type" and "object_id"

Fixes https://github.com/owncloud/activity/issues/652

- ~~BUG: cannot change from text to longtext because Doctrine ignores length changes, possibly related unmerged upstream PR: https://github.com/doctrine/dbal/pull/3182, also see https://github.com/doctrine/dbal/issues/2566~~ => now resorting to direct SQL
