### PR TITLE
Enable phpcs check for acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ endif
 PHPUNIT=php -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpunit"
 PHPUNITDBG=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpunit"
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
+PHP_CS=php -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpcs"
 
 all: build
 
@@ -159,6 +160,7 @@ test-js:
 test-php-style:            ## Run php-cs-fixer and check owncloud code-style
 test-php-style: vendor-bin/owncloud-codestyle/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes --dry-run
+	$(PHP_CS) --runtime-set ignore_warnings_on_exit --standard=../../phpcs.xml tests/acceptance
 
 .PHONY: test-php-style-fix
 test-php-style-fix:        ## Run php-cs-fixer and fix code style issues

--- a/tests/acceptance/features/bootstrap/ActivityContext.php
+++ b/tests/acceptance/features/bootstrap/ActivityContext.php
@@ -35,10 +35,15 @@ class ActivityContext implements Context {
 	 * @var FeatureContext
 	 */
 	private $featureContext;
-	
+
 	/**
 	 * @Then the activity number :index of user :user should match these properties:
+	 *
 	 * @param integer $index (starting from 1, newest to the oldest)
+	 * @param string $user
+	 * @param TableNode $expectedProperties
+	 *
+	 * @return void
 	 */
 	public function activityWithIndexShouldMatch(
 		$index, $user, TableNode $expectedProperties

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -26,7 +26,7 @@ require_once __DIR__ . '/../../../../../../tests/acceptance/features/bootstrap/b
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4(
 	"", __DIR__ . "/../../../../../../tests/acceptance/features/bootstrap", true
-	);
+);
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
 
 $classLoader->register();


### PR DESCRIPTION
This PR introduces PHPCS check for acceptance tests. This was only in core before, and uses the same phpcs and phpcs.xml  from there.