### PR TITLE
Test that activity log shows message on file/folder updates.

### DIFF
--- a/tests/acceptance/features/webUIActivity/createFilesFolder.feature
+++ b/tests/acceptance/features/webUIActivity/createFilesFolder.feature
@@ -39,6 +39,21 @@ Feature: Created files/folders activities
     When user "user0" browses to the activity page
     Then the activity number 1 should contain message "You created Doc3, Doc2, Doc1" in the activity page
 
+  Scenario: Uploading new file using async should register in the activity list
+    Given the administrator has enabled async operations
+    And using new DAV path
+    And user "user0" has uploaded the following chunks asynchronously to "/text.txt" with new chunking
+      | 1 | AAAAA |
+      | 2 | BBBBB |
+      | 3 | CCCCC |
+    When user "user0" browses to the activity page
+    Then the activity number 1 should contain message "You created text.txt" in the activity page
+
+  Scenario: Uploading new files using all mechanisms should be listed in the activity list
+    When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/text.txt" with all mechanisms using the WebDAV API
+    And user "user0" browses to the activity page
+    Then the activity number 1 should contain message "You created text.txt-newdav-newchunking, text.txt-newdav-regular, text.txt-olddav-oldchunking" in the activity page
+
   Scenario: Creating multiple folders should be listed in the activity list with contracted list
     Given user "user0" has created folder "Doc1"
     And user "user0" has created folder "Doc2"
@@ -53,3 +68,28 @@ Feature: Created files/folders activities
     And user "user0" has created folder "doc/nested"
     When user "user0" browses to the activity page
     Then the activity number 1 should contain message "You created nested, text1.txt, doc" in the activity page
+
+  Scenario: Creating files inside folder should be listed in the activity list
+    Given user "user0" has created folder "doc"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
+    When user "user0" browses to the activity page
+    Then the activity number 1 should contain message "You created text1.txt, doc" in the activity page
+
+  Scenario: Copying files should be shown in activity log
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text1.txt"
+    And user "user0" has copied file "/text1.txt" to "/text2.txt"
+    When user "user0" browses to the activity page
+    And the activity number 1 should contain message "You created text2.txt, text1.txt" in the activity page
+
+  Scenario: Copying folder should be shown in activity log as created
+    Given user "user0" has created folder "doc"
+    And user "user0" has copied file "/doc" to "/doc2"
+    When user "user0" browses to the activity page
+    And the activity number 1 should contain message "You created doc2, doc" in the activity page
+
+  Scenario: Copying files to another folder should be shown in log
+    Given user "user0" has created folder "doc"
+    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "user0" has copied file "/text.txt" to "/doc/text.txt"
+    When user "user0" browses to the activity page
+    And the activity number 1 should contain message "You created text.txt, text.txt, doc" in the activity page

--- a/tests/acceptance/features/webUIActivity/list.feature
+++ b/tests/acceptance/features/webUIActivity/list.feature
@@ -9,6 +9,12 @@ Feature: List activity
     And user "user0" has browsed to the activity page
     Then the activity number 1 should have message "You deleted lorem.txt" in the activity page
 
+  Scenario: folder deletion should be listed in the activity list
+    Given user "user0" has been created with default attributes
+    And user "user0" has deleted folder "simple-folder"
+    And user "user0" has browsed to the activity page
+    Then the activity number 1 should have message "You deleted simple-folder" in the activity page
+
   Scenario: folder share should be listed in the activity list
     Given these users have been created with default attributes but not initialized:
       | username |

--- a/tests/acceptance/features/webUIActivity/updateFilesFolder.feature
+++ b/tests/acceptance/features/webUIActivity/updateFilesFolder.feature
@@ -1,0 +1,47 @@
+@webUI @insulated @disablePreviews
+Feature: Updated files/folders activities
+  As a user
+  I want to be able to see activities of updated files/folders
+  So that I know what happened in my cloud storage
+
+  Background:
+    Given user "user0" has been created with default attributes
+
+  Scenario: Changing file contents should be shown in activity log
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    When user "user0" browses to the activity page
+    Then the activity number 1 should have message "You changed text.txt" in the activity page
+    And the activity number 2 should contain message "You created text.txt" in the activity page
+
+  Scenario: Changing multiple file contents should be shown in activity log
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
+    When user "user0" browses to the activity page
+    Then the activity number 1 should have message "You changed text1.txt and text.txt" in the activity page
+    And the activity number 2 should contain message "You created text1.txt, text.txt" in the activity page
+
+  Scenario: Changing multiple files in different order should be shown in activity log in the way it happens
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
+    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
+    When user "user0" browses to the activity page
+    Then the activity number 1 should have message "You changed text1.txt" in the activity page
+    And the activity number 2 should have message "You created text1.txt" in the activity page
+    And the activity number 3 should have message "You changed text.txt" in the activity page
+    And the activity number 4 should contain message "You created text.txt" in the activity page
+
+  Scenario: Changing contents of file inside folder should be shown in activity log
+    Given user "user0" has created folder "doc"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/doc/text.txt"
+    And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/doc/text1.txt"
+    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/doc/text1.txt"
+    When user "user0" browses to the activity page
+    Then the activity number 1 should have message "You changed text1.txt" in the activity page
+    And the activity number 2 should have message "You created text1.txt" in the activity page
+    And the activity number 3 should have message "You changed text.txt" in the activity page
+    And the activity number 4 should contain message "You created text.txt, doc" in the activity page


### PR DESCRIPTION
This adds a test for checking that the app registers the updates of files/folders correctly.

Currently, renaming files/folders (#375) and moving files/folders are not tracked.

Part of #677
