### PR TITLE
Add php_codesniffer to check acceptance test code style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ endif
 PHPUNIT=php -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpunit"
 PHPUNITDBG=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpunit"
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
+PHP_CODESNIFFER=vendor-bin/php_codesniffer/vendor/bin/phpcs
 
 all: build
 
@@ -157,8 +158,9 @@ test-js:
 
 .PHONY: test-php-style
 test-php-style:            ## Run php-cs-fixer and check owncloud code-style
-test-php-style: vendor-bin/owncloud-codestyle/vendor
+test-php-style: vendor-bin/owncloud-codestyle/vendor vendor-bin/php_codesniffer/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes --dry-run
+	$(PHP_CODESNIFFER) --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance
 
 .PHONY: test-php-style-fix
 test-php-style-fix:        ## Run php-cs-fixer and fix code style issues
@@ -212,3 +214,8 @@ vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-
 vendor-bin/owncloud-codestyle/composer.lock: vendor-bin/owncloud-codestyle/composer.json
 	@echo owncloud-codestyle composer.lock is not up to date.
 
+vendor-bin/php_codesniffer/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/php_codesniffer/composer.lock
+	composer bin php_codesniffer install --no-progress
+
+vendor-bin/php_codesniffer/composer.lock: vendor-bin/php_codesniffer/composer.json
+	@echo php_codesniffer composer.lock is not up to date.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<ruleset name="ownCloud Standard">
+	<description>ownCloud coding standard</description>
+	<arg name="colors" />
+	<arg value="sp" />
+
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/3rdparty/*</exclude-pattern>
+
+	<!-- make sure we use tabs for indent and not spaces -->
+	<arg name="tab-width" value="4" />
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent" />
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<properties>
+			<property name="indent" value="4" />
+			<property name="tabIndent" value="true" />
+		</properties>
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed" />
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed" />
+	</rule>
+
+	<rule ref="Generic.Files.LineLength">
+		<exclude name="Generic.Files.LineLength.TooLong" />
+	</rule>
+
+	<rule ref="PEAR">
+		<exclude name="Generic.Commenting.DocComment.ShortNotCapital" />
+		<exclude name="Generic.Commenting.DocComment.SpacingAfter" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
+		<exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
+		<exclude name="PEAR.Commenting.FileComment.IncompleteCopyright" />
+		<exclude name="PEAR.Commenting.FileComment.IncompleteLicense" />
+		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />
+		<exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
+		<exclude name="PEAR.Commenting.FileComment.MissingPackageTag" />
+		<exclude name="PEAR.Commenting.FileComment.MissingLicenseTag" />
+		<exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingPackageTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingLinkTag" />
+		<exclude name="PEAR.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamType" />
+		<exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamName" />
+		<exclude
+			name="PEAR.NamingConventions.ValidVariableName.PrivateNoUnderscore" />
+		<exclude
+			name="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore" />
+		<exclude name="PEAR.WhiteSpace.ScopeIndent.IncorrectExact" />
+		<exclude name="PEAR.Functions.FunctionDeclaration.BraceOnSameLine" />
+		<exclude name="PEAR.Classes.ClassDeclaration.OpenBraceNewLine" />
+	</rule>
+	<rule ref="Zend.Files.ClosingTag"/>
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
+	<rule ref="Squiz.Commenting.DocCommentAlignment" />
+	<rule ref="Generic.WhiteSpace.ScopeIndent" />
+	<rule ref="Squiz.Strings.ConcatenationSpacing">
+		<properties>
+			<property name="spacing" value="1" />
+			<property name="ignoreNewlines" value="true" />
+		</properties>
+	</rule>
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakIndent">
+		<exclude
+			name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonDEFAULT" />
+		<exclude
+			name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonCASE" />
+	</rule>
+	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+	<rule ref="Generic.Classes.OpeningBraceSameLine" />
+
+	<!-- storage wrapper uses php function names to wrap them -->
+	<rule ref="PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+		<exclude-pattern>*/lib/storagewrapper.php</exclude-pattern>
+	</rule>
+
+</ruleset>

--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "squizlabs/php_codesniffer": "3.*"
+    }
+}


### PR DESCRIPTION
Like was merged in core in https://github.com/owncloud/core/pull/34191

So that we know if we break our own rules for acceptance test code style.