### PR TITLE
Add test for simple tagging and commenting for activities

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -21,6 +21,8 @@ default:
             ocPath: apps/testing/api/v1/occ
         - WebUIGeneralContext:
         - TrashbinContext:
+        - TagsContext:
+        - CommentsContext:
         - ActivityContext:
 
     apiActivity:

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -23,6 +23,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\ActivityPage;
 use Page\LoginPage;
@@ -104,6 +105,35 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theUserFiltersActivityListBy($activityType) {
 		$this->activityPage->filterActivityListBy($this->getSession(), $activityType);
+	}
+
+	/**
+	 * @Then the comment message for activity number :index in the activity page should be:
+	 *
+	 * @param int $index
+	 * @param string $message
+	 *
+	 * @return void
+	 *
+	 * @throws \Exception
+	 */
+	public function theCommentMessageShouldBeListedOnTheActivityPage($index, PyStringNode $message) {
+		$commentMsg = $this->activityPage->getCommentMessageOfIndex($index - 1);
+		PHPUnit_Framework_Assert::assertNotNull($commentMsg, "Could not find comment message.");
+		PHPUnit_Framework_Assert::assertEquals($message, $commentMsg);
+	}
+
+	/**
+	 * @Then the activity number :index should not contain any comment message in the activity page
+	 *
+	 * @param int $index
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theActivityNumberShouldNotContainAnyCommentMessageInTheActivityPage($index) {
+		$commentMsg = $this->activityPage->getCommentMessageOfIndex($index - 1);
+		PHPUnit_Framework_Assert::assertNull($commentMsg, "Comment exists with content: $commentMsg");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/ActivityPage.php
+++ b/tests/acceptance/features/lib/ActivityPage.php
@@ -25,7 +25,6 @@ namespace Page;
 
 use PHPUnit_Framework_Assert;
 use Behat\Mink\Session;
-use Behat\Mink\Element\NodeElement;
 
 /**
  * Activity page.
@@ -43,6 +42,8 @@ class ActivityPage extends OwncloudPage {
 	protected $activityListXpath = "//div[@class='activitysubject']";
 	protected $avatarClassXpath = "(//div[@class='activitysubject'])[%s]//div[@class='avatar']";
 	protected $fileNameFieldXpath = "(//div[@class='activitysubject'])[%s]//a[@class='filename has-tooltip']";
+	protected $messageContainerXpath = "//div[@class='messagecontainer']";
+	protected $messageTextXpath = "//div[@class='activitymessage']";
 
 	protected $activityListFilterXpath = "//a[@data-navigation='%s']";
 
@@ -115,6 +116,24 @@ class ActivityPage extends OwncloudPage {
 		);
 		$filter->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * Return comment message of the given activity index
+	 *
+	 * @param string $index
+	 *
+	 * @return string|null
+	 * @throws \Exception
+	 */
+	public function getCommentMessageOfIndex($index) {
+		$messages = $this->findAll('xpath', $this->messageContainerXpath);
+		$message = $messages[$index];
+		$comment = $message->find('xpath', $this->messageTextXpath);
+		if ($comment === null) {
+			return null;
+		}
+		return $this->getTrimmedText($comment);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIActivity/comment.feature
+++ b/tests/acceptance/features/webUIActivity/comment.feature
@@ -1,0 +1,41 @@
+@webUI @insulated @disablePreviews
+Feature: Comment files/folders activities
+  As a user
+  I want to be able to see history of the files and folders that I have commented
+  So that I know what happened in my cloud storage
+
+  Background:
+    Given using new DAV path
+    And user "user0" has been created with default attributes
+
+  Scenario Outline: Commenting on a file/folder should be listed in the activity page
+    Given user "user0" has commented with content "My first comment" on file "<filepath><filename>"
+    When user "user0" browses to the activity page
+    Then the activity number 1 should contain message "You commented on <filename>" in the activity page
+    And the comment message for activity number 1 in the activity page should be:
+    """
+    My first comment
+    """
+    Examples:
+      | filepath                            | filename            |
+      | /                                   | lorem.txt           |
+      | simple-folder/                      | testapp.zip         |
+      | /                                   | 0                   |
+      | 'single'quotes/                     | simple-empty-folder |
+      | 0/                                  | lorem.txt           |
+      | 'single'quotes/simple-empty-folder/ | for-git-commit      |
+
+  Scenario Outline: Comment, and then deleting comment on a file/folder should be listed in the activity page without any comment
+    Given user "user0" has commented with content "My first comment" on file "<filepath><filename>"
+    And user "user0" has deleted the last created comment
+    When user "user0" browses to the activity page
+    Then the activity number 1 should contain message "You commented on <filename>" in the activity page
+    And the activity number 1 should not contain any comment message in the activity page
+    Examples:
+      | filepath                            | filename            |
+      | /                                   | lorem.txt           |
+      | simple-folder/                      | testapp.zip         |
+      | /                                   | 0                   |
+      | 'single'quotes/                     | simple-empty-folder |
+      | 0/                                  | lorem.txt           |
+      | 'single'quotes/simple-empty-folder/ | for-git-commit      |

--- a/tests/acceptance/features/webUIActivity/tags.feature
+++ b/tests/acceptance/features/webUIActivity/tags.feature
@@ -1,0 +1,21 @@
+@webUI @insulated @disablePreviews
+Feature: Tag files/folders activities
+  As a user
+  I want to be able to see history of the files and folders that I have tagged
+  So that I know what happened in my cloud storage
+
+  Scenario Outline: Adding a tag on a file/folder should be listed on the activity list
+    Given user "user0" has been created with default attributes
+    And user "user0" has created a "normal" tag with name "lorem"
+    # <filepath> already has an ending slash('/')
+    And user "user0" has added tag "lorem" to file "<filepath><filename>"
+    When user "user0" browses to the activity page
+    Then the activity number 1 should contain message "You assigned system tag lorem to <filename>" in the activity page
+    Examples:
+      | filepath                            | filename            |
+      | /                                   | lorem.txt           |
+      | simple-folder/                      | testapp.zip         |
+      | /                                   | 0                   |
+      | 'single'quotes/                     | simple-empty-folder |
+      | 0/                                  | lorem.txt           |
+      | 'single'quotes/simple-empty-folder/ | for-git-commit      |


### PR DESCRIPTION
This adds a simple test for tagging and commenting for activities.

Part of #677 