### PR TITLE
Add webUI tests for files sharing external

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 workspace:
   base: /var/www/owncloud
-  path: apps/activity
+  path: server/apps/activity
 
 branches: [ master, release* ]
 
@@ -9,6 +9,7 @@ pipeline:
     image: owncloudci/core
     version: ${OC_VERSION}
     pull: true
+    core_path: /var/www/owncloud/server
     db_type: ${DB_TYPE}
     db_name: ${DB_NAME}
     db_host: ${DB_TYPE}
@@ -18,16 +19,41 @@ pipeline:
       matrix:
         NEED_CORE: true
 
+  install-fed-server:
+    image: owncloudci/core
+    pull: true
+    version: ${FEDERATION_OC_VERSION}
+    core_path: /var/www/owncloud/fed-server
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
+  configure-federation-server:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+      - cd /var/www/owncloud/fed-server
+      - php occ a:l
+      - php occ a:e testing
+      - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=federated
+      - php occ log:manage --level 0
+      - php occ config:list
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
   install-app:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
-      - cd /var/www/owncloud/
+      - cd /var/www/owncloud/server
       - php occ a:l
       - php occ a:e activity
       - php occ a:e testing
       - php occ a:l
-      - php occ config:system:set trusted_domains 1 --value=owncloud
+      - php occ config:system:set trusted_domains 1 --value=server
       - php occ log:manage --level 0
     when:
       matrix:
@@ -38,8 +64,8 @@ pipeline:
     pull: true
     commands:
       - chown www-data /var/www/owncloud -R
-      - chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R
-      - chmod +x /var/www/owncloud/tests/acceptance/run.sh
+      - chmod 777 /var/www/owncloud/server/tests/acceptance/filesForUpload -R
+      - chmod +x /var/www/owncloud/server/tests/acceptance/run.sh
     when:
       matrix:
         NEED_SERVER: true
@@ -78,7 +104,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - TEST_SERVER_URL=http://owncloud
+      - TEST_SERVER_URL=http://server
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
       - make test-acceptance-api
@@ -93,10 +119,12 @@ pipeline:
       - BROWSER=chrome #chrome or firefox
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
-      - TEST_SERVER_URL=http://owncloud
+      - TEST_SERVER_URL=http://server
       - PLATFORM=Linux
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - touch /var/www/owncloud/saved-settings.sh
+      - . /var/www/owncloud/saved-settings.sh
       - make test-acceptance-webui
     when:
       matrix:
@@ -153,15 +181,25 @@ services:
       matrix:
         DB_TYPE: oci
 
-  owncloud:
+  server:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - APACHE_WEBROOT=/var/www/owncloud/
+      - APACHE_WEBROOT=/var/www/owncloud/server/
     command: ["/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND"]
     when:
       matrix:
         NEED_SERVER: true
+
+  federated:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - APACHE_WEBROOT=/var/www/owncloud/fed-server/
+    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D" , "FOREGROUND" ]
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
 
   selenium:
     image: selenium/standalone-chrome-debug:latest
@@ -282,6 +320,30 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-master-qa
+      TEST_SUITE: web-acceptance
+      BEHAT_SUITE: webUIActivitySharingExternal
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+
+    - PHP_VERSION: 7.1
+      OC_VERSION: daily-stable10-qa
+      TEST_SUITE: web-acceptance
+      BEHAT_SUITE: webUIActivitySharingExternal
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -25,6 +25,20 @@ default:
         - CommentsContext:
         - ActivityContext:
 
+    webUIActivitySharingExternal:
+      paths:
+        - '%paths.base%/../features/webUIActivitySharingExternal'
+      contexts:
+        - WebUIActivityContext:
+        - FeatureContext: *common_feature_context_params
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIFilesContext:
+        - WebUISharingContext:
+        - FederationContext:
+        - PublicWebDavContext:
+        - ActivityContext:
+
     apiActivity:
       paths:
         - '%paths.base%/../features/apiActivity'

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
@@ -1,0 +1,48 @@
+@webUI @insulated @disablePreviews
+Feature: public link sharing file/folders activities
+  As a user
+  I want to be able to see history of the files and folders shared externally
+  So that I know what happened in my cloud storage
+
+  Background:
+    Given user "user1" has been created with default attributes
+
+  Scenario: Creating a public link of a folder and file should be listed in the activity list
+    Given user "user1" has created a public link share of folder "simple-folder"
+    And user "user1" has created a public link share of file "textfile0.txt"
+    When user "user1" browses to the activity page
+    Then the activity number 1 should contain message "You shared textfile0.txt and simple-folder via link" in the activity page
+
+  Scenario: Uploading a file to a public shared folder should be listed in the activity list
+    Given user "user1" has created a public link share with settings
+      | path        | simple-folder |
+      | permissions | create        |
+    And the public has uploaded file "test.txt" with content "This is a test"
+    When user "user1" browses to the activity page
+    Then the activity number 1 should contain message "created test.txt" in the activity page
+
+  @issue-690
+  Scenario: Downloading a file from a public shared folder using API should be listed in the activity list
+    Given user "user1" has created a public link share of folder "simple-folder"
+    When the public downloads file "lorem.txt" from inside the last public shared folder with range "bytes=1-7" using the public WebDAV API
+    And user "user1" browses to the activity page
+    Then the activity number 1 should contain message "You shared simple-folder via link" in the activity page
+    #Then the activity number 1 should contain message "Public shared file lorem.txt was downloaded" in the activity page
+
+  Scenario: Downloading a public shared file from a webUI should be listed in the activity list
+    Given user "user1" has logged in using the webUI
+    And the user has created a new public link for file "textfile0.txt" using the webUI
+    And the user has logged out of the webUI
+    And the public accesses the last created public link using the webUI
+    When the public downloads the last created file using the webUI
+    And user "user1" browses to the activity page
+    Then the activity number 1 should contain message "Public shared file textfile0.txt was downloaded" in the activity page
+
+  Scenario: Downloading a public shared folder from a webUI should be listed in the activity list
+    Given user "user1" has logged in using the webUI
+    And the user has created a new public link for folder "simple-folder" using the webUI
+    And the user has logged out of the webUI
+    And the public accesses the last created public link using the webUI
+    When the public downloads the last created file using the webUI
+    And user "user1" browses to the activity page
+    Then the activity number 1 should contain message "Public shared folder simple-folder was downloaded" in the activity page

--- a/tests/acceptance/features/webUIActivitySharingExternal/sharingFederation.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/sharingFederation.feature
@@ -1,0 +1,41 @@
+@webUI @insulated @disablePreviews
+Feature: federation sharing file/folder activities
+  As a user
+  I want to be able to see history of the files and folders shared externally
+  So that I know what happened in my cloud storage
+
+  Background:
+    Given using server "REMOTE"
+    And user "user2" has been created with default attributes
+    And using server "LOCAL"
+    And user "user1" has been created with default attributes
+
+  Scenario: Sharing a folder with a remote server should not be listed in the activity list of a sharer if the sharee has not accepted the share
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user2" from server "REMOTE"
+    When user "user1" browses to the activity page
+    Then the activity should not have any message with keyword "remote share"
+
+  Scenario: Sharing a folder with a remote server should be listed in the activity list of a sharer
+    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user2" from server "REMOTE"
+    When user "user2" from server "REMOTE" accepts the last pending share using the sharing API
+    And user "user1" browses to the activity page
+    Then the activity number 1 should contain message "user2@… accepted remote share simple-folder" in the activity page
+
+  Scenario: Sharing a file with a remote server should be listed in the activity list of a sharer
+    Given user "user1" from server "LOCAL" has shared "textfile0.txt" with user "user2" from server "REMOTE"
+    When user "user2" from server "REMOTE" accepts the last pending share using the sharing API
+    And user "user1" browses to the activity page
+    Then the activity number 1 should contain message "user2@… accepted remote share textfile0.txt" in the activity page
+
+  Scenario: Sharing a file/folder with a remote server should be listed in the activity list of a sharee eventhough they have not accepted the sharee
+    Given user "user2" from server "REMOTE" has shared "textfile0.txt" with user "user1" from server "LOCAL"
+    And user "user2" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And user "user1" browses to the activity page
+    Then the activity number 1 should contain message "You received a new remote share simple-folder from user2@…" in the activity page
+    Then the activity number 2 should contain message "You received a new remote share textfile0.txt from user2@…" in the activity page
+
+  Scenario: remote sharee does not get new activity message after accepting the pending share
+    Given user "user2" from server "REMOTE" has shared "textfile0.txt" with user "user1" from server "LOCAL"
+    When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
+    And user "user1" browses to the activity page
+    Then the activity number 1 should contain message "You received a new remote share textfile0.txt from user2@…" in the activity page


### PR DESCRIPTION
## Description
The PR adds webUI acceptance tests for sharing activities related to external sharing.

## Related Issue
 #677 

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



P.S: Some of the steps used here are yet to be merged in [PR: owncloud/core/pull/34294]