### PR TITLE
remove login step from user browses to the activity page step

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -21,6 +21,7 @@ default:
             ocPath: apps/testing/api/v1/occ
         - WebUIGeneralContext:
         - TrashbinContext:
+        - WebUILoginContext:
         - TagsContext:
         - CommentsContext:
         - ActivityContext:

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -79,21 +79,17 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has browsed to the activity page
-	 * @When user :user browses to the activity page
-	 *
-	 * @param string $user
+	 * @Given the user has browsed to the activity page
+	 * @When the user browses to the activity page
 	 *
 	 * @return void
 	 */
-	public function userHasBrowsedToTheActivityPage($user) {
-		$this->loginPage->open();
-		$this->webUIGeneralContext->loginAs(
-			$user, $this->featureContext->getUserPassword($user)
-		);
-		$this->activityPage->open();
-		$this->activityPage->waitTillPageIsLoaded($this->getSession());
-		$this->webUIGeneralContext->setCurrentPageObject($this->activityPage);
+	public function userHasBrowsedToTheActivityPage() {
+		if (!$this->activityPage->isOpen()) {
+			$this->activityPage->open();
+			$this->activityPage->waitTillPageIsLoaded($this->getSession());
+			$this->webUIGeneralContext->setCurrentPageObject($this->activityPage);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/webUIActivity/comment.feature
+++ b/tests/acceptance/features/webUIActivity/comment.feature
@@ -7,10 +7,11 @@ Feature: Comment files/folders activities
   Background:
     Given using new DAV path
     And user "user0" has been created with default attributes
+    And user "user0" has logged in using the webUI
 
   Scenario Outline: Commenting on a file/folder should be listed in the activity page
     Given user "user0" has commented with content "My first comment" on file "<filepath><filename>"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You commented on <filename>" in the activity page
     And the comment message for activity number 1 in the activity page should be:
     """
@@ -28,7 +29,7 @@ Feature: Comment files/folders activities
   Scenario Outline: Comment, and then deleting comment on a file/folder should be listed in the activity page without any comment
     Given user "user0" has commented with content "My first comment" on file "<filepath><filename>"
     And user "user0" has deleted the last created comment
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You commented on <filename>" in the activity page
     And the activity number 1 should not contain any comment message in the activity page
     Examples:

--- a/tests/acceptance/features/webUIActivity/createFilesFolder.feature
+++ b/tests/acceptance/features/webUIActivity/createFilesFolder.feature
@@ -6,22 +6,23 @@ Feature: Created files/folders activities
 
   Background:
     Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
 
   Scenario: Creating new file should be listed in the activity list
     Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created text.txt" in the activity page
 
   Scenario: Creating new folder should be listed in the activity list
     Given user "user0" has created folder "Docs"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created Docs" in the activity page
 
   Scenario: Creating multiple files should be listed in the activity list
     Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created text2.txt, text1.txt, text.txt" in the activity page
 
   Scenario: Creating multiple files should be listed in the activity list with contracted list
@@ -29,14 +30,14 @@ Feature: Created files/folders activities
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text3.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created text3.txt, text2.txt, text1.txt" in the activity page
 
   Scenario: Creating multiple folders should be listed in the activity list
     Given user "user0" has created folder "Doc1"
     And user "user0" has created folder "Doc2"
     And user "user0" has created folder "Doc3"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created Doc3, Doc2, Doc1" in the activity page
 
   Scenario: Uploading new file using async should register in the activity list
@@ -46,12 +47,12 @@ Feature: Created files/folders activities
       | 1 | AAAAA |
       | 2 | BBBBB |
       | 3 | CCCCC |
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created text.txt" in the activity page
 
   Scenario: Uploading new files using all mechanisms should be listed in the activity list
     When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/text.txt" with all mechanisms using the WebDAV API
-    And user "user0" browses to the activity page
+    And the user browses to the activity page
     Then the activity number 1 should contain message "You created text.txt-newdav-newchunking, text.txt-newdav-regular, text.txt-olddav-oldchunking" in the activity page
 
   Scenario: Creating multiple folders should be listed in the activity list with contracted list
@@ -59,37 +60,37 @@ Feature: Created files/folders activities
     And user "user0" has created folder "Doc2"
     And user "user0" has created folder "Doc3"
     And user "user0" has created folder "Doc4"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created Doc4, Doc3, Doc2" in the activity page
 
   Scenario: Creating multiple folders and files should be listed in activity list
     Given user "user0" has created folder "doc"
     And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
     And user "user0" has created folder "doc/nested"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created nested, text1.txt, doc" in the activity page
 
   Scenario: Creating files inside folder should be listed in the activity list
     Given user "user0" has created folder "doc"
     And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You created text1.txt, doc" in the activity page
 
   Scenario: Copying files should be shown in activity log
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text1.txt"
     And user "user0" has copied file "/text1.txt" to "/text2.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     And the activity number 1 should contain message "You created text2.txt, text1.txt" in the activity page
 
   Scenario: Copying folder should be shown in activity log as created
     Given user "user0" has created folder "doc"
     And user "user0" has copied file "/doc" to "/doc2"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     And the activity number 1 should contain message "You created doc2, doc" in the activity page
 
   Scenario: Copying files to another folder should be shown in log
     Given user "user0" has created folder "doc"
     And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
     And user "user0" has copied file "/text.txt" to "/doc/text.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     And the activity number 1 should contain message "You created text.txt, text.txt, doc" in the activity page

--- a/tests/acceptance/features/webUIActivity/deleteAndRestore.feature
+++ b/tests/acceptance/features/webUIActivity/deleteAndRestore.feature
@@ -6,25 +6,26 @@ Feature: Deleted and Restored files/folders activities
 
   Background:
     Given user "user0" has been created with default attributes
+    And user "user0" has logged in using the webUI
 
   Scenario: file deletion should be listed in the activity list
     Given user "user0" has deleted file "lorem.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted lorem.txt" in the activity page
 
   Scenario: folder deletion should be listed in the activity list
     Given user "user0" has deleted folder "simple-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted simple-folder" in the activity page
 
   Scenario: file inside folder deleted should be listed in the activity list
     Given user "user0" has deleted file "simple-folder/block-aligned.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted block-aligned.txt" in the activity page
 
   Scenario: folder inside folder deleted should be listed in the activity list
     Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted simple-empty-folder" in the activity page
 
   Scenario: Deleting multiple folders should be listed in the activity list
@@ -33,7 +34,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has deleted folder "folder with space/simple-empty-folder"
     And user "user0" has deleted folder "'single'quotes"
     And user "user0" has deleted folder "strängé नेपाली folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted strängé नेपाली folder, 'single'quotes, simple-empty-folder, 0 and simple-empty-folder" in the activity page
 
   Scenario: Deleting 6 or more folders at once should be contracted in the activity list
@@ -43,7 +44,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has deleted folder "'single'quotes"
     And user "user0" has deleted folder "strängé नेपाली folder"
     And user "user0" has deleted folder "strängé नेपाली folder empty"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted strängé नेपाली folder empty, strängé नेपाली folder, 'single'quotes and 3 more" in the activity page
 
   Scenario: Deleting multiple files should be listed in the activity list
@@ -52,7 +53,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has deleted file "data.zip"
     And user "user0" has deleted file "textfile0.txt"
     And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted testavatar.png, textfile0.txt, data.zip, lorem.txt and lorem.txt" in the activity page
 
   Scenario: Deleting 6 or more files at once should be contracted in the activity list
@@ -62,7 +63,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has deleted file "textfile0.txt"
     And user "user0" has deleted file "'single'quotes/for-git-commit"
     And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted testavatar.png, for-git-commit, textfile0.txt and 3 more" in the activity page
 
   Scenario: Deleting mix of files and folders at once should be listed in the activity list
@@ -71,7 +72,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has deleted folder "'single'quotes"
     And user "user0" has deleted file "textfile0.txt"
     And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
 
   Scenario: Deleting mix of files and folders 6 or more at once should be contracted in the activity list
@@ -81,34 +82,34 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has deleted file "textfile0.txt"
     And user "user0" has deleted folder "folder with space/simple-empty-folder"
     And user "user0" has deleted file "data.zip"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted data.zip, simple-empty-folder, textfile0.txt and 3 more" in the activity page
 
   Scenario: Restoring deleted folder should be listed in the activity list
     Given user "user0" has deleted folder "simple-folder"
     And user "user0" has restored the folder with original path "simple-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-folder" in the activity page
     And the activity number 2 should have message "You deleted simple-folder" in the activity page
 
   Scenario: Restoring folder that was inside a folder should be listed in the activity list
     Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
     And user "user0" has restored the folder with original path "simple-folder/simple-empty-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-empty-folder" in the activity page
     And the activity number 2 should have message "You deleted simple-empty-folder" in the activity page
 
   Scenario: Restoring deleted file should be listed in the activity list
     Given user "user0" has deleted folder "lorem.txt"
     And user "user0" has restored the folder with original path "lorem.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt" in the activity page
     And the activity number 2 should have message "You deleted lorem.txt" in the activity page
 
   Scenario: Restoring deleted file that was inside a folder should be listed in the activity list
     Given user "user0" has deleted folder "simple-folder/lorem.txt"
     And user "user0" has restored the folder with original path "simple-folder/lorem.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt" in the activity page
     And the activity number 2 should have message "You deleted lorem.txt" in the activity page
 
@@ -123,7 +124,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
     And user "user0" has restored the folder with original path "0"
     And user "user0" has restored the folder with original path "simple-folder/simple-empty-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-empty-folder, 0, simple-empty-folder, 'single'quotes and strängé नेपाली folder" in the activity page
     And the activity number 2 should have message "You deleted strängé नेपाली folder, 'single'quotes, simple-empty-folder, 0 and simple-empty-folder" in the activity page
 
@@ -140,7 +141,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
     And user "user0" has restored the folder with original path "0"
     And user "user0" has restored the folder with original path "simple-folder/simple-empty-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-empty-folder, 0, simple-empty-folder and 3 more" in the activity page
     And the activity number 2 should have message "You deleted strängé नेपाली folder empty, strängé नेपाली folder, 'single'quotes and 3 more" in the activity page
 
@@ -155,7 +156,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the file with original path "data.zip"
     And user "user0" has restored the file with original path "lorem.txt"
     And user "user0" has restored the file with original path "simple-folder/lorem.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt, lorem.txt, data.zip, textfile0.txt and testavatar.png" in the activity page
     And the activity number 2 should have message "You deleted testavatar.png, textfile0.txt, data.zip, lorem.txt and lorem.txt" in the activity page
 
@@ -172,7 +173,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the file with original path "data.zip"
     And user "user0" has restored the file with original path "lorem.txt"
     And user "user0" has restored the file with original path "simple-folder/lorem.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt, lorem.txt, data.zip and 3 more" in the activity page
     And the activity number 2 should have message "You deleted testavatar.png, for-git-commit, textfile0.txt and 3 more" in the activity page
 
@@ -187,7 +188,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the folder with original path "'single'quotes"
     And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
     And user "user0" has restored the folder with original path "0"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored 0, testavatar.png, 'single'quotes, textfile0.txt and simple-empty-folder" in the activity page
     And the activity number 2 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
 
@@ -204,7 +205,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the folder with original path "'single'quotes"
     And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
     And user "user0" has restored the folder with original path "0"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored 0, testavatar.png, 'single'quotes and 3 more" in the activity page
     And the activity number 2 should have message "You deleted data.zip, simple-empty-folder, textfile0.txt and 3 more" in the activity page
 
@@ -219,7 +220,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the folder with original path "'single'quotes"
     And user "user0" has restored the folder with original path "0"
     And user "user0" has restored the file with original path "textfile0.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored textfile0.txt, 0, 'single'quotes, simple-empty-folder and testavatar.png" in the activity page
     And the activity number 2 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
 
@@ -234,7 +235,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has restored the file with original path "textfile0.txt"
     And user "user0" has deleted folder "folder with space/simple-empty-folder"
     And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-empty-folder" in the activity page
     And the activity number 2 should have message "You deleted simple-empty-folder" in the activity page
     And the activity number 3 should have message "You restored textfile0.txt" in the activity page
@@ -262,7 +263,7 @@ Feature: Deleted and Restored files/folders activities
     And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
     And user "user0" has deleted file "textfile0.txt"
     And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You deleted simple-empty-folder, textfile0.txt, testavatar.png, 'single'quotes and 0" in the activity page
     And the activity number 2 should have message "You restored textfile0.txt, 0, 'single'quotes, simple-empty-folder and testavatar.png" in the activity page
     And the activity number 3 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page

--- a/tests/acceptance/features/webUIActivity/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivity/sharingInternal.feature
@@ -16,7 +16,8 @@ Feature: Sharing file/folders activities
     And user "user0" has shared folder "folder with space" with user "user2"
     And user "user0" has shared file "simple-folder/lorem.txt" with user "user1"
     And user "user0" has shared folder "simple-folder/simple-empty-folder" with user "user2"
-    When user "user0" browses to the activity page
+    And user "user0" has logged in using the webUI
+    When the user browses to the activity page
     Then the activity number 1 should have a message saying that you have shared folder "simple-empty-folder" with user "User Two"
     And the activity number 2 should have a message saying that you have shared file "lorem.txt" with user "User One"
     And the activity number 3 should have a message saying that you have shared folder "folder with space" with user "User Two"
@@ -39,7 +40,8 @@ Feature: Sharing file/folders activities
     And user "user0" has shared folder "folder with space" with group "grp2"
     And user "user0" has shared file "simple-folder/lorem.txt" with group "grp1"
     And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "grp2"
-    When user "user0" browses to the activity page
+    And user "user0" has logged in using the webUI
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You shared simple-empty-folder with group grp2" in the activity page
     And the activity number 2 should contain message "You shared lorem.txt with group grp1" in the activity page
     And the activity number 3 should contain message "You shared folder with space with group grp2" in the activity page
@@ -61,7 +63,8 @@ Feature: Sharing file/folders activities
     And user "user0" has shared folder "folder with space" with user "user1"
     And user "user0" has shared file "simple-folder/lorem.txt" with user "user1"
     And user "user0" has shared folder "simple-folder/simple-empty-folder" with user "user1"
-    When user "user1" browses to the activity page
+    And user "user1" has logged in using the webUI
+    When the user browses to the activity page
     Then the activity number 1 should have a message saying that user "User Zero" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
     When the user filters activity list by "Activities by you"
     Then the activity should not have any message with keyword "shared"
@@ -76,7 +79,8 @@ Feature: Sharing file/folders activities
     And user "user0" has shared folder "folder with space" with group "grp1"
     And user "user0" has shared file "simple-folder/lorem.txt" with group "grp1"
     And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "grp1"
-    When user "user1" browses to the activity page
+    And user "user1" has logged in using the webUI
+    When the user browses to the activity page
     Then the activity number 1 should have a message saying that user "User Zero" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
     When the user filters activity list by "Activities by you"
     Then the activity should not have any message with keyword "shared"

--- a/tests/acceptance/features/webUIActivity/tags.feature
+++ b/tests/acceptance/features/webUIActivity/tags.feature
@@ -6,10 +6,11 @@ Feature: Tag files/folders activities
 
   Scenario Outline: Adding a tag on a file/folder should be listed on the activity list
     Given user "user0" has been created with default attributes
+    And user "user0" has logged in using the webUI
     And user "user0" has created a "normal" tag with name "lorem"
     # <filepath> already has an ending slash('/')
     And user "user0" has added tag "lorem" to file "<filepath><filename>"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You assigned system tag lorem to <filename>" in the activity page
     Examples:
       | filepath                            | filename            |

--- a/tests/acceptance/features/webUIActivity/updateFilesFolder.feature
+++ b/tests/acceptance/features/webUIActivity/updateFilesFolder.feature
@@ -6,11 +6,12 @@ Feature: Updated files/folders activities
 
   Background:
     Given user "user0" has been created with default attributes
+    And user "user0" has logged in using the webUI
 
   Scenario: Changing file contents should be shown in activity log
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
     And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You changed text.txt" in the activity page
     And the activity number 2 should contain message "You created text.txt" in the activity page
 
@@ -19,7 +20,7 @@ Feature: Updated files/folders activities
     And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
     And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
     And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You changed text1.txt and text.txt" in the activity page
     And the activity number 2 should contain message "You created text1.txt, text.txt" in the activity page
 
@@ -28,7 +29,7 @@ Feature: Updated files/folders activities
     And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
     And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
     And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You changed text1.txt" in the activity page
     And the activity number 2 should have message "You created text1.txt" in the activity page
     And the activity number 3 should have message "You changed text.txt" in the activity page
@@ -40,7 +41,7 @@ Feature: Updated files/folders activities
     And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/doc/text.txt"
     And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/doc/text1.txt"
     And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/doc/text1.txt"
-    When user "user0" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should have message "You changed text1.txt" in the activity page
     And the activity number 2 should have message "You created text1.txt" in the activity page
     And the activity number 3 should have message "You changed text.txt" in the activity page

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
@@ -6,11 +6,12 @@ Feature: public link sharing file/folders activities
 
   Background:
     Given user "user1" has been created with default attributes
+    And user "user1" has logged in using the webUI
 
   Scenario: Creating a public link of a folder and file should be listed in the activity list
     Given user "user1" has created a public link share of folder "simple-folder"
     And user "user1" has created a public link share of file "textfile0.txt"
-    When user "user1" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You shared textfile0.txt and simple-folder via link" in the activity page
 
   Scenario: Uploading a file to a public shared folder should be listed in the activity list
@@ -18,31 +19,27 @@ Feature: public link sharing file/folders activities
       | path        | simple-folder |
       | permissions | create        |
     And the public has uploaded file "test.txt" with content "This is a test"
-    When user "user1" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "created test.txt" in the activity page
 
   @issue-690
   Scenario: Downloading a file from a public shared folder using API should be listed in the activity list
     Given user "user1" has created a public link share of folder "simple-folder"
     When the public downloads file "lorem.txt" from inside the last public shared folder with range "bytes=1-7" using the public WebDAV API
-    And user "user1" browses to the activity page
+    And the user browses to the activity page
     Then the activity number 1 should contain message "You shared simple-folder via link" in the activity page
     #Then the activity number 1 should contain message "Public shared file lorem.txt was downloaded" in the activity page
 
   Scenario: Downloading a public shared file from a webUI should be listed in the activity list
-    Given user "user1" has logged in using the webUI
-    And the user has created a new public link for file "textfile0.txt" using the webUI
-    And the user has logged out of the webUI
+    Given the user has created a new public link for file "textfile0.txt" using the webUI
     And the public accesses the last created public link using the webUI
     When the public downloads the last created file using the webUI
-    And user "user1" browses to the activity page
+    And the user browses to the activity page
     Then the activity number 1 should contain message "Public shared file textfile0.txt was downloaded" in the activity page
 
   Scenario: Downloading a public shared folder from a webUI should be listed in the activity list
-    Given user "user1" has logged in using the webUI
-    And the user has created a new public link for folder "simple-folder" using the webUI
-    And the user has logged out of the webUI
+    Given the user has created a new public link for folder "simple-folder" using the webUI
     And the public accesses the last created public link using the webUI
     When the public downloads the last created file using the webUI
-    And user "user1" browses to the activity page
+    And the user browses to the activity page
     Then the activity number 1 should contain message "Public shared folder simple-folder was downloaded" in the activity page

--- a/tests/acceptance/features/webUIActivitySharingExternal/sharingFederation.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/sharingFederation.feature
@@ -9,33 +9,34 @@ Feature: federation sharing file/folder activities
     And user "user2" has been created with default attributes
     And using server "LOCAL"
     And user "user1" has been created with default attributes
+    And user "user1" has logged in using the webUI
 
   Scenario: Sharing a folder with a remote server should not be listed in the activity list of a sharer if the sharee has not accepted the share
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user2" from server "REMOTE"
-    When user "user1" browses to the activity page
+    When the user browses to the activity page
     Then the activity should not have any message with keyword "remote share"
 
   Scenario: Sharing a folder with a remote server should be listed in the activity list of a sharer
     Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user2" from server "REMOTE"
     When user "user2" from server "REMOTE" accepts the last pending share using the sharing API
-    And user "user1" browses to the activity page
+    And the user browses to the activity page
     Then the activity number 1 should contain message "user2@… accepted remote share simple-folder" in the activity page
 
   Scenario: Sharing a file with a remote server should be listed in the activity list of a sharer
     Given user "user1" from server "LOCAL" has shared "textfile0.txt" with user "user2" from server "REMOTE"
     When user "user2" from server "REMOTE" accepts the last pending share using the sharing API
-    And user "user1" browses to the activity page
+    And the user browses to the activity page
     Then the activity number 1 should contain message "user2@… accepted remote share textfile0.txt" in the activity page
 
   Scenario: Sharing a file/folder with a remote server should be listed in the activity list of a sharee eventhough they have not accepted the sharee
     Given user "user2" from server "REMOTE" has shared "textfile0.txt" with user "user1" from server "LOCAL"
     And user "user2" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" browses to the activity page
+    When the user browses to the activity page
     Then the activity number 1 should contain message "You received a new remote share simple-folder from user2@…" in the activity page
-    Then the activity number 2 should contain message "You received a new remote share textfile0.txt from user2@…" in the activity page
+    And the activity number 2 should contain message "You received a new remote share textfile0.txt from user2@…" in the activity page
 
   Scenario: remote sharee does not get new activity message after accepting the pending share
     Given user "user2" from server "REMOTE" has shared "textfile0.txt" with user "user1" from server "LOCAL"
     When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
-    And user "user1" browses to the activity page
+    And the user browses to the activity page
     Then the activity number 1 should contain message "You received a new remote share textfile0.txt from user2@…" in the activity page


### PR DESCRIPTION
# Description
Remove login step from `user browses to activity page` step. 
This makes testing easier as we can move from one page to another without logging user out and then again logging in the user.