### PR TITLE
fix waitTillPageIsLoaded() for activity page with no activity

### DIFF
--- a/tests/acceptance/features/lib/ActivityPage.php
+++ b/tests/acceptance/features/lib/ActivityPage.php
@@ -38,6 +38,7 @@ class ActivityPage extends OwncloudPage {
 	protected $path = '/index.php/apps/activity';
 
 	protected $activityContainerXpath = "//div[@class='boxcontainer']";
+	protected $noActivityIconXpath = "//div[@class='icon-activity']";
 
 	protected $activityListXpath = "//div[@class='activitysubject']";
 	protected $avatarClassXpath = "(//div[@class='activitysubject'])[%s]//div[@class='avatar']";
@@ -148,8 +149,13 @@ class ActivityPage extends OwncloudPage {
 		Session $session,
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
-		$this->waitTillXpathIsVisible(
+		$container = $this->waitTillElementIsNotNull(
 			$this->activityContainerXpath, $timeout_msec
 		);
+		if ($container === null) {
+			$this->waitTillXpathIsVisible(
+				$this->noActivityIconXpath, $timeout_msec
+			);
+		}
 	}
 }


### PR DESCRIPTION
# Description
Current xpath `activityContainerXpath` only works when there is at least one activity in the activity page
but when there is no activity it doesn't work.

So, a new check is introduced to make `waitTillPageIsLoaded()` work for both the cases.