### PR TITLE
Add tests for admin tags activity logs

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -70,6 +70,16 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	private $userSharedWithUserMsgFramework = "%s%s shared %s with %s%s";
 
 	/**
+	 * @var string
+	 */
+	private $userCreatedSystemTagMsgFramework = "%s%s created system tag %s";
+
+	/**
+	 * @var string
+	 */
+	private $userDeletedSystemTagMsgFramework = "%s%s deleted system tag %s";
+
+	/**
 	 * WebUIAdminSharingSettingsContext constructor.
 	 *
 	 * @param ActivityPage $activityPage
@@ -261,6 +271,39 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		foreach ($activities as $activity) {
 			PHPUnit_Framework_Assert::assertNotContains($tag, $activity);
 		}
+	}
+
+	/**
+	 * @Then /^the activity number (\d+) should have a message saying that user "([^"]*)" (created|deleted) system tag "([^"]*)"$/
+	 *
+	 * @param integer $index (starting from 1, newest to the oldest)
+	 * @param string $user
+	 * @param string $createdOrDeleted
+	 * @param string $tagName
+	 *
+	 * @return void
+	 */
+	public function theActivityNumberShouldHaveAMessageSayingThatUserCreatedOrDeletedSystemTagLorem(
+		$index, $user, $createdOrDeleted, $tagName
+	) {
+		if ($index < 1) {
+			throw new InvalidArgumentException(
+				"activity index starts from 1"
+			);
+		}
+		$avatarText = \strtoupper($user[0]);
+		if ($createdOrDeleted === "created") {
+			$msgFramework = $this->userCreatedSystemTagMsgFramework;
+		} else {
+			$msgFramework = $this->userDeletedSystemTagMsgFramework;
+		}
+		$message = \sprintf(
+			$msgFramework, $avatarText, $user, $tagName
+		);
+		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
+			$index - 1
+		);
+		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIActivity/tags.feature
+++ b/tests/acceptance/features/webUIActivity/tags.feature
@@ -117,3 +117,31 @@ Feature: Tag files/folders activities
     Then the activity number 1 should have message "You assigned system tag simple to simple-empty-folder" in the activity page
     And the activity number 2 should have a message saying that user "User One" has shared "simple-empty-folder" with you
     And the activity should not have any message with keyword "User Zero"
+
+  Scenario: Activity for creating a normal system tag by a user should be listed in activity list of an admin
+    Given user "user0" has been created with default attributes
+    And user "user0" has created a "normal" tag with name "lorem"
+    And the administrator has logged in using the webUI
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" created system tag "lorem"
+
+  Scenario: Activity for deleting a normal system tag by a user should be listed in activity list of an admin
+    Given user "user0" has been created with default attributes
+    And user "user0" has created a "normal" tag with name "lorem"
+    And user "user0" has deleted the tag with name "lorem"
+    And the administrator has logged in using the webUI
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" deleted system tag "lorem"
+
+  Scenario: Activity for creating a static system tag by a administrator should be listed in activity list of an admin
+    Given the administrator has created a "static" tag with name "StaticTagName"
+    And the administrator has logged in using the webUI
+    When the user browses to the activity page
+    Then the activity number 1 should have message "You created system tag StaticTagName (static)" in the activity page
+
+  Scenario: Activity for deleting a static system tag by a administrator should be listed in activity list of an admin
+    Given the administrator has created a "static" tag with name "StaticTagName"
+    And the administrator has deleted the tag with name "StaticTagName"
+    And the administrator has logged in using the webUI
+    When the user browses to the activity page
+    Then the activity number 1 should have message "You deleted system tag StaticTagName (static)" in the activity page


### PR DESCRIPTION
## Description
The PR adds webUI acceptance tests for admin tags activity logs.

## Related Issue
 #677 

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.



P.S: Some of the steps used here are yet to be merged in [PR: owncloud/core/pull/34294]