### PR TITLE
Add tests for internal sharing operations

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -87,6 +87,36 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	private $userDeletedSystemTagMsgFramework = "%s%s deleted system tag %s";
 
 	/**
+	 * @var string
+	 */
+	private $userCreatedMsgFramework = "%s%s created %s";
+
+	/**
+	 * @var string
+	 */
+	private $userDeletedMsgFramework = "%s%s deleted %s";
+
+	/**
+	 * @var string
+	 */
+	private $userChangedMsgFramework = "%s%s changed %s";
+
+	/**
+	 * @var string
+	 */
+	private $youRemovedTheShareOfForMsgFramework = "You removed the share of %s%s for %s";
+
+	/**
+	 * @var string
+	 */
+	private $userRemovedTheShareOfForMsgFramework = "%s%s removed the share of %s%s for %s";
+
+	/**
+	 * @var string
+	 */
+	private $userRemovedTheShareForMsgFramework = "%s%s removed the share for %s";
+
+	/**
 	 * WebUIAdminSharingSettingsContext constructor.
 	 *
 	 * @param ActivitySettingForm $activitySettingForm
@@ -343,6 +373,117 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		PHPUnit_Framework_Assert::assertEmpty(
 			$activities, "Activity list was expected to be empty but was not"
 		);
+	}
+
+	/**
+	 * @Then /^the activity number (\d+) should have a message saying that user "([^"]*)" (created|deleted|changed) "([^"]*)"$/
+	 *
+	 * @param integer $index
+	 * @param string $user
+	 * @param string $createdDeletedOrChanged
+	 * @param string $entry
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theActivityNumberShouldHaveAMessageUserCreatedOrDeletedOrChanged(
+		$index, $user, $createdDeletedOrChanged, $entry
+	) {
+		if ($index < 1) {
+			throw new InvalidArgumentException(
+				"activity index starts from 1"
+			);
+		}
+		$avatarText = \strtoupper($user[0]);
+		if ($createdDeletedOrChanged === "created") {
+			$msgFramework = $this->userCreatedMsgFramework;
+		} elseif ($createdDeletedOrChanged === "deleted") {
+			$msgFramework = $this->userDeletedMsgFramework;
+		} else {
+			$msgFramework = $this->userChangedMsgFramework;
+		}
+		$message = \sprintf(
+			$msgFramework, $avatarText, $user, $entry
+		);
+		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
+			$index - 1
+		);
+		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+	}
+
+	/**
+	 * @Then /^the activity number (\d+) should have a message saying that (you|"[^"]*") removed the share of "([^"]*)" for "([^"]*)"$/
+	 *
+	 * @param integer $index
+	 * @param string $youOrUser
+	 * @param string $sharer
+	 * @param string $entry
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theActivityNumberShouldHaveAMessageSayingThatYouRemovedTheShareOfFor(
+		$index, $youOrUser, $sharer, $entry
+	) {
+		if ($index < 1) {
+			throw new InvalidArgumentException(
+				"activity index starts from 1"
+			);
+		}
+		$sharerAvaterText = \strtoupper($sharer[0]);
+		if ($youOrUser === "you") {
+			$message = \sprintf(
+				$this->youRemovedTheShareOfForMsgFramework,
+				$sharerAvaterText,
+				$sharer,
+				$entry
+			);
+		} else {
+			$youOrUser = \trim($youOrUser, '"');
+			$userAvatarText = \strtoupper($youOrUser[0]);
+			$message = \sprintf(
+				$this->userRemovedTheShareOfForMsgFramework,
+				$userAvatarText,
+				$youOrUser,
+				$sharerAvaterText,
+				$sharer,
+				$entry
+			);
+		}
+		
+		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
+			$index - 1
+		);
+		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+	}
+
+	/**
+	 * @Then /^the activity number (\d+) should have a message saying that "([^"]*)" removed the share for "([^"]*)"$/
+	 *
+	 * @param integer $index
+	 * @param string $user
+	 * @param string $entry
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theActivityNumberShouldHaveAMessageSayingThatRemovedTheShareFor($index, $user, $entry) {
+		if ($index < 1) {
+			throw new InvalidArgumentException(
+				"activity index starts from 1"
+			);
+		}
+		$userAvatarText = \strtoupper($user[0]);
+		$message = \sprintf(
+			$this->userRemovedTheShareForMsgFramework,
+			$userAvatarText,
+			$user,
+			$entry
+		);
+		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
+			$index - 1
+		);
+		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIActivity/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivity/sharingInternal.feature
@@ -140,3 +140,149 @@ Feature: Sharing file/folders activities
     When the user disables activity log stream for "shared" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "shared"
+
+  Scenario: Uploading a file inside a shared folder by a sharee should be listed in the activity list of a sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/textfilemoved.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User One" created "textfilemoved.txt"
+
+  Scenario: Creating a folder inside a shared folder by a sharee should be listed in the activity list of a sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has created folder "simple-folder/newFolder"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User One" created "newFolder"
+
+  Scenario: Uploading a file inside a shared folder by a sharer should be listed in the activity list of a sharee
+    Given user "user1" has been created with default attributes
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/textfilemoved.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" created "textfilemoved.txt"
+
+  Scenario: Creating a folder inside a shared folder by a sharer should be listed in the activity list of a sharee
+    Given user "user1" has been created with default attributes
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "simple-folder/newFolder"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" created "newFolder"
+
+  Scenario: Deleting a file inside a shared folder by a sharee should be listed in the activity list of a sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has deleted file "simple-folder/lorem.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User One" deleted "lorem.txt"
+
+  Scenario: Deleting a folder inside a shared folder by a sharee should be listed in the activity list of a sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has deleted folder "simple-folder/simple-empty-folder"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User One" deleted "simple-empty-folder"
+
+  Scenario: Deleting a file inside a shared folder by a sharer should be listed in the activity list of a sharee
+    Given user "user1" has been created with default attributes
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has deleted file "simple-folder/lorem.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" deleted "lorem.txt"
+
+  Scenario: Deleting a folder inside a shared folder by a sharer should be listed in the activity list of a sharee
+    Given user "user1" has been created with default attributes
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has deleted folder "simple-folder/simple-empty-folder"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" deleted "simple-empty-folder"
+
+  Scenario: Changing a shared file by a sharee should be listed in the activity list of a sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared file "lorem.txt" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has uploaded file "filesForUpload/new-lorem-big.txt" to "lorem.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User One" changed "lorem.txt"
+
+  Scenario: Changing a file inside a shared folder by a sharee should be listed in the activity list of a sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has uploaded file "filesForUpload/new-lorem-big.txt" to "simple-folder/lorem.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User One" changed "lorem.txt"
+
+  Scenario: Changing a shared file by a sharer should be listed in the activity list of a sharee
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared file "lorem.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "lorem.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" changed "lorem.txt"
+
+  Scenario: Changing a file inside a shared folder by a sharer should be listed in the activity list of a sharee
+    Given user "user1" has been created with default attributes
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "simple-folder/lorem.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" changed "lorem.txt"
+
+  Scenario: Creating a folder inside a shared folder by a sharer should be listed in the activity list of a sharee even after the sharee has unshared the share
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "simple-folder/newFolder"
+    And user "user1" has declined the share "/simple-folder" offered by user "user0"
+    And the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User Zero" created "newFolder"
+
+  Scenario: Creating a folder inside a shared folder by a sharee should be listed in the activity list of a sharer even after the sharee has unshared the share
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has created folder "simple-folder/newFolder"
+    And user "user1" has declined the share "/simple-folder" offered by user "user0"
+    And the user browses to the activity page
+    Then the activity number 1 should have a message saying that user "User One" created "newFolder"
+
+  Scenario: Deleting a share by a sharer should be listed in the activity list of the sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user0" has deleted the last share
+    And the user browses to the activity page
+    Then the activity number 1 should have a message saying that "User Zero" removed the share for "simple-folder"
+
+  Scenario: Deleting a share by a sharer should be listed in the activity list of the sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user0" has deleted the last share
+    And the user browses to the activity page
+    Then the activity number 1 should have a message saying that you removed the share of "User One" for "simple-folder"
+
+  Scenario: Deleting a share by a sharee should be listed in the activity list of the sharee
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user1" has deleted the last share
+    And the user browses to the activity page
+    Then the activity number 1 should have a message saying that "User One" removed the share for "simple-folder"
+
+  Scenario: Deleting a share by a sharee should be listed in the activity list of the sharer
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
+    And user "user1" has deleted the last share
+    And the user browses to the activity page
+    Then the activity number 1 should have a message saying that "User One" removed the share of "User One" for "simple-folder"


### PR DESCRIPTION
## Description
The PR adds webUI acceptance tests sharing internal operations

## Related Issue
 #677 

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.