### PR TITLE
PHPunit 5 to 6 preparation

### DIFF
--- a/tests/Unit/ConsumerTest.php
+++ b/tests/Unit/ConsumerTest.php
@@ -34,10 +34,10 @@ class ConsumerTest extends TestCase {
 	/** @var \OCA\Activity\Consumer */
 	protected $consumer;
 
-	/** @var \OCA\Activity\Data|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\Data|\PHPUnit\Framework\MockObject\MockObject */
 	protected $data;
 
-	/** @var \OCP\L10N\IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\L10N\IFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l10nFactory;
 
 	/** @var \OCA\Activity\UserSettings */

--- a/tests/Unit/Controller/ActivitiesTest.php
+++ b/tests/Unit/Controller/ActivitiesTest.php
@@ -32,19 +32,19 @@ use OCP\Template;
  * @package OCA\Activity\Tests\Controller
  */
 class ActivitiesTest extends TestCase {
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCA\Activity\Data|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\Data|\PHPUnit\Framework\MockObject\MockObject */
 	protected $data;
 
-	/** @var \OCA\Activity\Navigation|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\Navigation|\PHPUnit\Framework\MockObject\MockObject */
 	protected $navigation;
 
-	/** @var \OCP\IAvatarManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IAvatarManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $avatarManager;
 
 	/** @var Activities */

--- a/tests/Unit/Controller/FeedTest.php
+++ b/tests/Unit/Controller/FeedTest.php
@@ -27,25 +27,25 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Util;
 
 class FeedTest extends TestCase {
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCA\Activity\Data|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\Data|\PHPUnit\Framework\MockObject\MockObject */
 	protected $data;
 
-	/** @var \OCA\Activity\GroupHelper|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\GroupHelper|\PHPUnit\Framework\MockObject\MockObject */
 	protected $helper;
 
-	/** @var \OCA\Activity\UserSettings|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\UserSettings|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSettings;
 
-	/** @var \OCP\Activity\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Activity\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $manager;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
 	/** @var \OCP\IL10N */
@@ -76,7 +76,7 @@ class FeedTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var $urlGenerator \OCP\IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+		/** @var $urlGenerator \OCP\IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
 		$urlGenerator = $this->getMockBuilder('OCP\IURLGenerator')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Controller/OCSEndPointTest.php
+++ b/tests/Unit/Controller/OCSEndPointTest.php
@@ -33,37 +33,37 @@ use OCP\AppFramework\Http;
  * @package OCA\Activity\Tests\Controller
  */
 class OCSEndPointTest extends TestCase {
-	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var \OCA\Activity\Data|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\Data|\PHPUnit\Framework\MockObject\MockObject */
 	protected $data;
 
-	/** @var \OCA\Activity\GroupHelper|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\GroupHelper|\PHPUnit\Framework\MockObject\MockObject */
 	protected $helper;
 
-	/** @var \OCA\Activity\UserSettings|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\UserSettings|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSettings;
 
-	/** @var \OCP\IPreview|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IPreview|\PHPUnit\Framework\MockObject\MockObject */
 	protected $preview;
 
-	/** @var \OCP\IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
 	protected $urlGenerator;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
 
-	/** @var \OCP\Files\IMimeTypeDetector|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Files\IMimeTypeDetector|\PHPUnit\Framework\MockObject\MockObject */
 	protected $mimeTypeDetector;
 
-	/** @var \OC\Files\View|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Files\View|\PHPUnit\Framework\MockObject\MockObject */
 	protected $view;
 
-	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit\Framework\MockObject\MockObject */
 	protected $infoCache;
 
-	/** @var \OCP\IAvatarManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IAvatarManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $avatarManager;
 
 	/** @var \OCP\IL10N */

--- a/tests/Unit/Controller/SettingsTest.php
+++ b/tests/Unit/Controller/SettingsTest.php
@@ -35,22 +35,22 @@ use OCP\Security\ISecureRandom;
 use OCP\Util;
 
 class SettingsTest extends TestCase {
-	/** @var IConfig |  \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig |  \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	protected $request;
 
-	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	protected $urlGenerator;
 
-	/** @var Data | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var Data | \PHPUnit\Framework\MockObject\MockObject */
 	protected $data;
 
-	/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var ISecureRandom | \PHPUnit\Framework\MockObject\MockObject */
 	protected $random;
 
-	/** @var UserSettings | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var UserSettings | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userSettings;
 
 	/** @var \OCP\IL10N */
@@ -59,7 +59,7 @@ class SettingsTest extends TestCase {
 	/** @var Settings */
 	protected $controller;
 
-	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
 	private $user;
 
 	protected function setUp() {

--- a/tests/Unit/DataHelperTest.php
+++ b/tests/Unit/DataHelperTest.php
@@ -25,13 +25,13 @@ use OCA\Activity\DataHelper;
 
 class DataHelperTest extends TestCase {
 	protected $originalWEBROOT;
-	/** @var \OCP\Activity\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Activity\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $activityManager;
-	/** @var \OCA\Activity\Parameter\Factory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\Parameter\Factory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $parameterFactory;
-	/** @var \OCP\L10N\IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\L10N\IFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l10Nfactory;
-	/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
 	protected function setUp() {
@@ -64,7 +64,7 @@ class DataHelperTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return DataHelper|\PHPUnit_Framework_MockObject_MockObject
+	 * @return DataHelper|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getHelper(array $methods = []) {
 		if (empty($methods)) {
@@ -280,7 +280,7 @@ class DataHelperTest extends TestCase {
 	 * @param array $expected
 	 */
 	public function testGetParameters($parsing, $parameterString, array $parameters, array $parameterTypes, array $factoryCalls, array $expected) {
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/DataTest.php
+++ b/tests/Unit/DataTest.php
@@ -38,10 +38,10 @@ class DataTest extends TestCase {
 	/** @var \OCP\IL10N */
 	protected $activityLanguage;
 
-	/** @var \OC\Activity\Manager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Activity\Manager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $activityManager;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
 	protected function setUp() {
@@ -245,7 +245,7 @@ class DataTest extends TestCase {
 		$activities[4] = $this->populateActivity(4, 'user1', 'user2', 'type2', $objectType, $objectId);
 		$activities[5] = $this->populateActivity(5, 'user2', 'user1', 'type2', $objectType, $objectId);
 
-		/** @var \OCA\Activity\GroupHelper|\PHPUnit_Framework_MockObject_MockObject $groupHelper */
+		/** @var \OCA\Activity\GroupHelper|\PHPUnit\Framework\MockObject\MockObject $groupHelper */
 		$groupHelper = $this->getMockBuilder('OCA\Activity\GroupHelper')
 			->disableOriginalConstructor()
 			->getMock();
@@ -253,7 +253,7 @@ class DataTest extends TestCase {
 			->method('setUser')
 			->with('user1');
 
-		/** @var \OCA\Activity\UserSettings|\PHPUnit_Framework_MockObject_MockObject $settings */
+		/** @var \OCA\Activity\UserSettings|\PHPUnit\Framework\MockObject\MockObject $settings */
 		$settings = $this->getMockBuilder('OCA\Activity\UserSettings')
 			->disableOriginalConstructor()
 			->getMock();
@@ -262,7 +262,7 @@ class DataTest extends TestCase {
 			->with('user1', 'stream')
 			->willReturn(['type1', 'type2']);
 
-		/** @var \OC\Activity\Manager|\PHPUnit_Framework_MockObject_MockObject $activityManager */
+		/** @var \OC\Activity\Manager|\PHPUnit\Framework\MockObject\MockObject $activityManager */
 		$activityManager = $this->getMockBuilder('OCP\Activity\IManager')
 			->disableOriginalConstructor()
 			->getMock();
@@ -275,7 +275,7 @@ class DataTest extends TestCase {
 			->with($filter)
 			->willReturn([null, null]);
 
-		/** @var \OCA\Activity\Data|\PHPUnit_Framework_MockObject_MockObject $data */
+		/** @var \OCA\Activity\Data|\PHPUnit\Framework\MockObject\MockObject $data */
 		$data = new \OCA\Activity\Data(
 			$activityManager,
 			\OC::$server->getDatabaseConnection(),
@@ -301,7 +301,7 @@ class DataTest extends TestCase {
 	 * @expectedExceptionCode 3
 	 */
 	public function testGetNoSettings() {
-		/** @var \OCA\Activity\GroupHelper|\PHPUnit_Framework_MockObject_MockObject $groupHelper */
+		/** @var \OCA\Activity\GroupHelper|\PHPUnit\Framework\MockObject\MockObject $groupHelper */
 		$groupHelper = $this->getMockBuilder('OCA\Activity\GroupHelper')
 			->disableOriginalConstructor()
 			->getMock();
@@ -309,7 +309,7 @@ class DataTest extends TestCase {
 			->method('setUser')
 			->with('user1');
 
-		/** @var \OCA\Activity\UserSettings|\PHPUnit_Framework_MockObject_MockObject $settings */
+		/** @var \OCA\Activity\UserSettings|\PHPUnit\Framework\MockObject\MockObject $settings */
 		$settings = $this->getMockBuilder('OCA\Activity\UserSettings')
 			->disableOriginalConstructor()
 			->getMock();
@@ -318,7 +318,7 @@ class DataTest extends TestCase {
 			->with('user1', 'stream')
 			->willReturn(['settings']);
 
-		/** @var \OC\Activity\Manager|\PHPUnit_Framework_MockObject_MockObject $activityManager */
+		/** @var \OC\Activity\Manager|\PHPUnit\Framework\MockObject\MockObject $activityManager */
 		$activityManager = $this->getMockBuilder('OCP\Activity\IManager')
 			->disableOriginalConstructor()
 			->getMock();
@@ -329,7 +329,7 @@ class DataTest extends TestCase {
 		$activityManager->expects($this->never())
 			->method('getQueryForFilter');
 
-		/** @var \OCA\Activity\Data|\PHPUnit_Framework_MockObject_MockObject $data */
+		/** @var \OCA\Activity\Data|\PHPUnit\Framework\MockObject\MockObject $data */
 		$data = new \OCA\Activity\Data(
 			$activityManager,
 			\OC::$server->getDatabaseConnection(),
@@ -345,12 +345,12 @@ class DataTest extends TestCase {
 	 * @expectedExceptionCode 1
 	 */
 	public function testGetNoUser() {
-		/** @var \OCA\Activity\GroupHelper|\PHPUnit_Framework_MockObject_MockObject $groupHelper */
+		/** @var \OCA\Activity\GroupHelper|\PHPUnit\Framework\MockObject\MockObject $groupHelper */
 		$groupHelper = $this->getMockBuilder('OCA\Activity\GroupHelper')
 			->disableOriginalConstructor()
 			->getMock();
 
-		/** @var \OCA\Activity\UserSettings|\PHPUnit_Framework_MockObject_MockObject $settings */
+		/** @var \OCA\Activity\UserSettings|\PHPUnit\Framework\MockObject\MockObject $settings */
 		$settings = $this->getMockBuilder('OCA\Activity\UserSettings')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/FilesHooksTest.php
+++ b/tests/Unit/FilesHooksTest.php
@@ -37,17 +37,17 @@ use OCP\Share;
 class FilesHooksTest extends TestCase {
 	/** @var \OCA\Activity\FilesHooks */
 	protected $filesHooks;
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\Activity\IManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\Activity\IManager */
 	protected $activityManager;
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCA\Activity\Data */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCA\Activity\Data */
 	protected $data;
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCA\Activity\UserSettings */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCA\Activity\UserSettings */
 	protected $settings;
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\IGroupManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\IGroupManager */
 	protected $groupManager;
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OC\Files\View */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Files\View */
 	protected $view;
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\IURLGenerator */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\IURLGenerator */
 	protected $urlGenerator;
 
 	protected function setUp() {
@@ -81,7 +81,7 @@ class FilesHooksTest extends TestCase {
 	/**
 	 * @param array $mockedMethods
 	 * @param string $user
-	 * @return FilesHooks|\PHPUnit_Framework_MockObject_MockObject
+	 * @return FilesHooks|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getFilesHooks(array $mockedMethods = [], $user = 'user') {
 		if (!empty($mockedMethods)) {

--- a/tests/Unit/Formatter/BaseFormatterTest.php
+++ b/tests/Unit/Formatter/BaseFormatterTest.php
@@ -29,7 +29,7 @@ class BaseFormatterTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return IFormatter|\PHPUnit_Framework_MockObject_MockObject
+	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getFormatter(array $methods = []) {
 		if (empty($methods)) {
@@ -57,7 +57,7 @@ class BaseFormatterTest extends TestCase {
 	 * @param string $expected
 	 */
 	public function testFormat($parameter, $expected) {
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Formatter/CloudIDFormatterTest.php
+++ b/tests/Unit/Formatter/CloudIDFormatterTest.php
@@ -26,7 +26,7 @@ use OCA\Activity\Formatter\IFormatter;
 use OCA\Activity\Tests\Unit\TestCase;
 
 class CloudIDFormatterTest extends TestCase {
-	/** @var \OCP\Contacts\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Contacts\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;
 
 	protected function setUp() {
@@ -39,7 +39,7 @@ class CloudIDFormatterTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return IFormatter|\PHPUnit_Framework_MockObject_MockObject
+	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getFormatter(array $methods = []) {
 		if (empty($methods)) {
@@ -73,7 +73,7 @@ class CloudIDFormatterTest extends TestCase {
 	 * @param string $expected
 	 */
 	public function testFormat($parameter, $expected) {
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Formatter/FileFormatterTest.php
+++ b/tests/Unit/Formatter/FileFormatterTest.php
@@ -26,13 +26,13 @@ use OCA\Activity\Formatter\IFormatter;
 use OCA\Activity\Tests\Unit\TestCase;
 
 class FileFormatterTest extends TestCase {
-	/** @var \OCP\IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
 	protected $urlGenerator;
 
-	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit\Framework\MockObject\MockObject */
 	protected $infoCache;
 
-	/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
 	protected function setUp() {
@@ -59,7 +59,7 @@ class FileFormatterTest extends TestCase {
 	/**
 	 * @param array $methods
 	 * @param string $user
-	 * @return IFormatter|\PHPUnit_Framework_MockObject_MockObject
+	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getFormatter(array $methods = [], $user = 'user') {
 		if (empty($methods)) {
@@ -120,7 +120,7 @@ class FileFormatterTest extends TestCase {
 	 * @param string $expected
 	 */
 	public function testFormat($user, $parameter, $isDir, array $info, $expected) {
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Formatter/GroupFormatterTest.php
+++ b/tests/Unit/Formatter/GroupFormatterTest.php
@@ -29,12 +29,12 @@ use OCP\IGroupManager;
 
 class GroupFormatterTest extends TestCase {
 
-	/** @var  \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var  \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
 	/**
 	 * @param array $methods
-	 * @return IFormatter|\PHPUnit_Framework_MockObject_MockObject
+	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getFormatter(array $methods = []) {
 		if (empty($methods)) {
@@ -63,7 +63,7 @@ class GroupFormatterTest extends TestCase {
 	 * @param string $expected
 	 */
 	public function testFormat($parameter, $expected) {
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Formatter/UserFormatterTest.php
+++ b/tests/Unit/Formatter/UserFormatterTest.php
@@ -27,10 +27,10 @@ use OCA\Activity\Tests\Unit\TestCase;
 
 class UserFormatterTest extends TestCase {
 
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
-	/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
 	protected function setUp() {
@@ -47,7 +47,7 @@ class UserFormatterTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return IFormatter|\PHPUnit_Framework_MockObject_MockObject
+	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getFormatter(array $methods = []) {
 		if (empty($methods)) {
@@ -78,7 +78,7 @@ class UserFormatterTest extends TestCase {
 	 * @param string $expected
 	 */
 	public function testFormatRemoteUser($expected) {
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();
@@ -121,7 +121,7 @@ class UserFormatterTest extends TestCase {
 	 * @param string $expected
 	 */
 	public function testFormat($parameter, $user, $expected) {
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/GroupHelperTest.php
+++ b/tests/Unit/GroupHelperTest.php
@@ -25,9 +25,9 @@ use OCA\Activity\GroupHelper;
 use OCA\Activity\Parameter\Collection;
 
 class GroupHelperTest extends TestCase {
-	/** @var \OCP\Activity\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Activity\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $activityManager;
-	/** @var \OCA\Activity\DataHelper|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\DataHelper|\PHPUnit\Framework\MockObject\MockObject */
 	protected $dataHelper;
 
 	protected function setUp() {
@@ -45,7 +45,7 @@ class GroupHelperTest extends TestCase {
 	/**
 	 * @param array $methods
 	 * @param bool $grouping
-	 * @return GroupHelper|\PHPUnit_Framework_MockObject_MockObject
+	 * @return GroupHelper|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getHelper(array $methods = [], $grouping = false) {
 		if (empty($methods)) {

--- a/tests/Unit/MailQueueHandlerTest.php
+++ b/tests/Unit/MailQueueHandlerTest.php
@@ -36,19 +36,19 @@ class MailQueueHandlerTest extends TestCase {
 	/** @var MailQueueHandler */
 	protected $mailQueueHandler;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\Mail\IMailer */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\Mail\IMailer */
 	protected $mailer;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $message;
 
 	/** @var \OCP\IUserManager */
 	protected $userManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCP\Activity\IManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\Activity\IManager */
 	protected $activityManager;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\OCA\Activity\DataHelper */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCA\Activity\DataHelper */
 	protected $dataHelper;
 
 	/** @var IUser */

--- a/tests/Unit/MailQueueHandlerTest.php
+++ b/tests/Unit/MailQueueHandlerTest.php
@@ -278,7 +278,9 @@ class MailQueueHandlerTest extends TestCase {
 	 * Should not throw an exception
 	 */
 	public function testDeleteSentItemsWithNoUsers() {
-		$this->mailQueueHandler->deleteSentItems([], \time());
+		$this->assertNull(
+			$this->mailQueueHandler->deleteSentItems([], \time())
+		);
 	}
 
 	/**

--- a/tests/Unit/Parameter/CollectionTest.php
+++ b/tests/Unit/Parameter/CollectionTest.php
@@ -25,7 +25,7 @@ use OCA\Activity\Parameter\Collection;
 use OCA\Activity\Tests\Unit\TestCase;
 
 class CollectionTest extends TestCase {
-	/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
 	protected function setUp() {
@@ -39,7 +39,7 @@ class CollectionTest extends TestCase {
 	/**
 	 * @param array $methods
 	 * @param string $random
-	 * @return Collection|\PHPUnit_Framework_MockObject_MockObject
+	 * @return Collection|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getCollection(array $methods = [], $random = 'random') {
 		if (empty($methods)) {
@@ -133,7 +133,7 @@ class CollectionTest extends TestCase {
 	public function testAddParameter() {
 		$collection = $this->getCollection();
 
-		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit_Framework_MockObject_MockObject $parameter1 */
+		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit\Framework\MockObject\MockObject $parameter1 */
 		$parameter1 = $this->getMockBuilder('OCA\Activity\Parameter\IParameter')
 			->disableOriginalConstructor()
 			->getMock();
@@ -141,7 +141,7 @@ class CollectionTest extends TestCase {
 			->method('getParameter')
 			->willReturn('One');
 
-		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit_Framework_MockObject_MockObject $parameter2 */
+		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit\Framework\MockObject\MockObject $parameter2 */
 		$parameter2 = $this->getMockBuilder('OCA\Activity\Parameter\IParameter')
 			->disableOriginalConstructor()
 			->getMock();
@@ -161,7 +161,7 @@ class CollectionTest extends TestCase {
 	public function testFormat() {
 		$collection = $this->getCollection();
 
-		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit_Framework_MockObject_MockObject $parameter1 */
+		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit\Framework\MockObject\MockObject $parameter1 */
 		$parameter1 = $this->getMockBuilder('OCA\Activity\Parameter\IParameter')
 			->disableOriginalConstructor()
 			->getMock();
@@ -169,7 +169,7 @@ class CollectionTest extends TestCase {
 			->method('format')
 			->willReturn('OneNull');
 
-		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit_Framework_MockObject_MockObject $parameter2 */
+		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit\Framework\MockObject\MockObject $parameter2 */
 		$parameter2 = $this->getMockBuilder('OCA\Activity\Parameter\IParameter')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Parameter/FactoryTest.php
+++ b/tests/Unit/Parameter/FactoryTest.php
@@ -26,28 +26,28 @@ use OCA\Activity\Tests\Unit\TestCase;
 use OCP\IGroupManager;
 
 class FactoryTest extends TestCase {
-	/** @var \OCP\Activity\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Activity\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $activityManager;
 
-	/** @var \OCP\IUserManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
-	/** @var \OCP\IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
 	protected $urlGenerator;
 
-	/** @var \OCP\Contacts\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Contacts\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;
 
-	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit\Framework\MockObject\MockObject */
 	protected $infoCache;
 
-	/** @var \OCP\IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
-	/** @var  \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var  \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
 	protected function setUp() {
@@ -87,7 +87,7 @@ class FactoryTest extends TestCase {
 	/**
 	 * @param array $methods
 	 * @param string $user
-	 * @return Factory|\PHPUnit_Framework_MockObject_MockObject
+	 * @return Factory|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getFactory(array $methods = [], $user = 'user') {
 		if (empty($methods)) {
@@ -144,7 +144,7 @@ class FactoryTest extends TestCase {
 		$factory = $this->getFactory();
 		$this->assertSame($this->l, $this->invokePrivate($factory, 'l'));
 
-		/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject $l2 */
+		/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject $l2 */
 		$l2 = $this->getMockBuilder('OCP\IL10N')
 			->disableOriginalConstructor()
 			->getMock();
@@ -170,7 +170,7 @@ class FactoryTest extends TestCase {
 	public function testGetParameter($parameter, $formatter) {
 		$factory = $this->getFactory(['getFormatter']);
 
-		/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject $event */
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Parameter/ParameterTest.php
+++ b/tests/Unit/Parameter/ParameterTest.php
@@ -25,9 +25,9 @@ use OCA\Activity\Parameter\Parameter;
 use OCA\Activity\Tests\Unit\TestCase;
 
 class ParameterTest extends TestCase {
-	/** @var \OCP\Activity\IEvent|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject */
 	protected $event;
-	/** @var \OCA\Activity\Formatter\IFormatter|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\Formatter\IFormatter|\PHPUnit\Framework\MockObject\MockObject */
 	protected $formatter;
 
 	protected function setUp() {

--- a/tests/Unit/UserSettingsTest.php
+++ b/tests/Unit/UserSettingsTest.php
@@ -29,7 +29,7 @@ class UserSettingsTest extends TestCase {
 	/** @var UserSettings */
 	protected $userSettings;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
 	protected function setUp() {

--- a/tests/Unit/ViewInfoCacheTest.php
+++ b/tests/Unit/ViewInfoCacheTest.php
@@ -25,10 +25,10 @@ use OCA\Activity\ViewInfoCache;
 use OCP\Files\NotFoundException;
 
 class ViewInfoCacheTest extends TestCase {
-	/** @var \OC\Files\View|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Files\View|\PHPUnit\Framework\MockObject\MockObject */
 	protected $view;
 
-	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit\Framework\MockObject\MockObject */
 	protected $infoCache;
 
 	protected function setUp() {
@@ -41,7 +41,7 @@ class ViewInfoCacheTest extends TestCase {
 
 	/**
 	 * @param array $methods
-	 * @return ViewInfoCache|\PHPUnit_Framework_MockObject_MockObject
+	 * @return ViewInfoCache|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	public function getCache(array $methods = []) {
 		if (empty($methods)) {

--- a/tests/acceptance/features/bootstrap/ActivityContext.php
+++ b/tests/acceptance/features/bootstrap/ActivityContext.php
@@ -56,7 +56,7 @@ class ActivityContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user)
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $response->getStatusCode()
 		);
 		$responseDecoded = \json_decode(
@@ -64,13 +64,13 @@ class ActivityContext implements Context {
 		);
 		$activityData = $responseDecoded['ocs']['data'][$index - 1];
 		foreach ($expectedProperties->getRowsHash() as $key => $value) {
-			PHPUnit_Framework_Assert::assertArrayHasKey(
+			PHPUnit\Framework\Assert::assertArrayHasKey(
 				$key, $activityData
 			);
 			$value = $this->featureContext->substituteInLineCodes(
 				$value, ['preg_quote' => ['/']]
 			);
-			PHPUnit_Framework_Assert::assertNotFalse(
+			PHPUnit\Framework\Assert::assertNotFalse(
 				(bool)\preg_match($value, $activityData[$key]),
 				"'$value' does not match '{$activityData[$key]}'"
 			);

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -198,8 +198,8 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theCommentMessageShouldBeListedOnTheActivityPage($index, PyStringNode $message) {
 		$commentMsg = $this->activityPage->getCommentMessageOfIndex($index);
-		PHPUnit_Framework_Assert::assertNotNull($commentMsg, "Could not find comment message.");
-		PHPUnit_Framework_Assert::assertEquals($message, $commentMsg);
+		PHPUnit\Framework\Assert::assertNotNull($commentMsg, "Could not find comment message.");
+		PHPUnit\Framework\Assert::assertEquals($message, $commentMsg);
 	}
 
 	/**
@@ -212,7 +212,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theActivityNumberShouldNotContainAnyCommentMessageInTheActivityPage($index) {
 		$commentMsg = $this->activityPage->getCommentMessageOfIndex($index);
-		PHPUnit_Framework_Assert::assertNull($commentMsg, "Comment exists with content: $commentMsg");
+		PHPUnit\Framework\Assert::assertNull($commentMsg, "Comment exists with content: $commentMsg");
 	}
 
 	/**
@@ -231,7 +231,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		}
 		$message = $this->featureContext->substituteInLineCodes($message);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -258,7 +258,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		// the username initial is shown in the webUI
 		$message = \sprintf($this->youSharedMsgFramework, $entry, $avatarText, $user);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -271,7 +271,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theActivityNumberShouldContainMessageInTheActivityPage($index, $message) {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertContains($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertContains($message, $latestActivityMessage);
 	}
 
 	/**
@@ -296,7 +296,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$avatarText = \strtoupper($user[0]);
 		$message = \sprintf($this->sharedWithYouMsgFramework, $avatarText, $user, $entry);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -331,7 +331,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 			$user2
 		);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -344,7 +344,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	public function theActivityShouldNotHaveAnyMessageWithKeyword($tag) {
 		$activities = $this->activityPage->getAllActivityMessageLists();
 		foreach ($activities as $activity) {
-			PHPUnit_Framework_Assert::assertNotContains($tag, $activity);
+			PHPUnit\Framework\Assert::assertNotContains($tag, $activity);
 		}
 	}
 
@@ -384,7 +384,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -394,7 +394,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theActivityListShouldBeEmpty() {
 		$activities = $this->activityPage->getAllActivityMessageLists();
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$activities,
 			"Activity list was expected to be empty but was not"
 		);
@@ -434,7 +434,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -483,7 +483,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -512,7 +512,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -536,7 +536,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 			\strtoupper($user[0]),
 			$user
 		);
-		PHPUnit_Framework_Assert::assertEquals($expectedMsg, $actualMsg);
+		PHPUnit\Framework\Assert::assertEquals($expectedMsg, $actualMsg);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/ActivityPage.php
+++ b/tests/acceptance/features/lib/ActivityPage.php
@@ -23,7 +23,7 @@
  */
 namespace Page;
 
-use PHPUnit_Framework_Assert;
+use PHPUnit\Framework\Assert;
 use Behat\Mink\Session;
 
 /**
@@ -62,7 +62,7 @@ class ActivityPage extends OwncloudPage {
 	 */
 	public function getActivityMessageOfIndex($index) {
 		$activities = $this->getAllActivityMessageLists();
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			$index,
 			$activities,
 			__METHOD__ .
@@ -105,7 +105,7 @@ class ActivityPage extends OwncloudPage {
 			'Antivirus' => 'files_antivirus',
 			'Files' => 'files'
 		];
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			$activityType,
 			$activityFilters,
 			__METHOD__ .


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0

1) Adjust `PHPUnit_Framework_*` to be `PHPUnit\Framework\*` (this works now in PHPUnit5 also)
"PHPUnit's units of code are now namespaced. For instance, PHPUnit_Framework_TestCase is now PHPUnit\Framework\TestCase"

2) Add `assertNull()` wrapper to tests that call a method that is expected to return nothing.
PHPUnit6 does more reporting of "risky" tests. A test that has no assertion is considered "risky". Sometimes there are valid tests like that - a test that calls some method, the method has no return and the only external behavior is that the method will throw an exception if it "does not work". In that case, the method "returning" `null` is the indication that it "worked.
This will avoid these tests being reported as "risky".

This passes on PHPUnit5, so could be merged [prior to|in preparation for] updating to PHPUnit6.