### PR TITLE
Run CI against bump-phpunit-6 to do PHPUnit6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ branches: [ master, release* ]
 pipeline:
   install-core:
     image: owncloudci/core
-    version: ${OC_VERSION}
+    git_reference: ${GIT_REFERENCE}
     pull: true
     core_path: /var/www/owncloud/server
     db_type: ${DB_TYPE}
@@ -216,6 +216,7 @@ matrix:
 
     # Unit Tests
     - PHP_VERSION: 7.0
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
@@ -225,6 +226,7 @@ matrix:
       COVERAGE: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
@@ -234,6 +236,7 @@ matrix:
       COVERAGE: true
 
     - PHP_VERSION: 7.2
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: sqlite
@@ -243,6 +246,7 @@ matrix:
       COVERAGE: true
 
     - PHP_VERSION: 7.0
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: oci
@@ -251,6 +255,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.0
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: mysql
@@ -259,6 +264,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.0
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: phpunit
       DB_TYPE: pgsql
@@ -267,6 +273,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: pgsql
@@ -276,6 +283,7 @@ matrix:
       COVERAGE: true
 
     - PHP_VERSION: 7.2
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: phpunit
       DB_TYPE: pgsql
@@ -284,6 +292,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.2
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: javascript
       DB_TYPE: mysql
@@ -294,6 +303,7 @@ matrix:
     # acceptance tests
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityComments
@@ -304,6 +314,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityComments
@@ -314,6 +325,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityCreateUpdate
@@ -324,6 +336,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityCreateUpdate
@@ -334,6 +347,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityDeleteRestore
@@ -344,6 +358,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityDeleteRestore
@@ -354,6 +369,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingExternal
@@ -366,6 +382,7 @@ matrix:
       FEDERATION_OC_VERSION: daily-stable10-qa
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingExternal
@@ -378,6 +395,7 @@ matrix:
       FEDERATION_OC_VERSION: daily-stable10-qa
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingInternal
@@ -390,6 +408,7 @@ matrix:
       FEDERATION_OC_VERSION: daily-stable10-qa
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingInternal
@@ -402,6 +421,7 @@ matrix:
       FEDERATION_OC_VERSION: daily-stable10-qa
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityTags
@@ -412,6 +432,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityTags
@@ -422,6 +443,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: bump-phpunit-6
       OC_VERSION: daily-master-qa
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiActivity
@@ -432,6 +454,7 @@ matrix:
       NEED_INSTALL_APP: true
 
     - PHP_VERSION: 7.1
+      GIT_REFERENCE: stable10-bump-phpunit-6
       OC_VERSION: daily-stable10-qa
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiActivity

--- a/tests/acceptance/features/bootstrap/ActivityContext.php
+++ b/tests/acceptance/features/bootstrap/ActivityContext.php
@@ -56,7 +56,7 @@ class ActivityContext implements Context {
 			$user,
 			$this->featureContext->getPasswordForUser($user)
 		);
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit\Framework\Assert::assertEquals(
 			200, $response->getStatusCode()
 		);
 		$responseDecoded = \json_decode(
@@ -64,13 +64,13 @@ class ActivityContext implements Context {
 		);
 		$activityData = $responseDecoded['ocs']['data'][$index - 1];
 		foreach ($expectedProperties->getRowsHash() as $key => $value) {
-			PHPUnit_Framework_Assert::assertArrayHasKey(
+			PHPUnit\Framework\Assert::assertArrayHasKey(
 				$key, $activityData
 			);
 			$value = $this->featureContext->substituteInLineCodes(
 				$value, ['preg_quote' => ['/']]
 			);
-			PHPUnit_Framework_Assert::assertNotFalse(
+			PHPUnit\Framework\Assert::assertNotFalse(
 				(bool)\preg_match($value, $activityData[$key]),
 				"'$value' does not match '{$activityData[$key]}'"
 			);

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -198,8 +198,8 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theCommentMessageShouldBeListedOnTheActivityPage($index, PyStringNode $message) {
 		$commentMsg = $this->activityPage->getCommentMessageOfIndex($index);
-		PHPUnit_Framework_Assert::assertNotNull($commentMsg, "Could not find comment message.");
-		PHPUnit_Framework_Assert::assertEquals($message, $commentMsg);
+		PHPUnit\Framework\Assert::assertNotNull($commentMsg, "Could not find comment message.");
+		PHPUnit\Framework\Assert::assertEquals($message, $commentMsg);
 	}
 
 	/**
@@ -212,7 +212,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theActivityNumberShouldNotContainAnyCommentMessageInTheActivityPage($index) {
 		$commentMsg = $this->activityPage->getCommentMessageOfIndex($index);
-		PHPUnit_Framework_Assert::assertNull($commentMsg, "Comment exists with content: $commentMsg");
+		PHPUnit\Framework\Assert::assertNull($commentMsg, "Comment exists with content: $commentMsg");
 	}
 
 	/**
@@ -231,7 +231,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		}
 		$message = $this->featureContext->substituteInLineCodes($message);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -258,7 +258,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		// the username initial is shown in the webUI
 		$message = \sprintf($this->youSharedMsgFramework, $entry, $avatarText, $user);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -271,7 +271,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theActivityNumberShouldContainMessageInTheActivityPage($index, $message) {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertContains($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertContains($message, $latestActivityMessage);
 	}
 
 	/**
@@ -296,7 +296,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$avatarText = \strtoupper($user[0]);
 		$message = \sprintf($this->sharedWithYouMsgFramework, $avatarText, $user, $entry);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -331,7 +331,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 			$user2
 		);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -344,7 +344,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	public function theActivityShouldNotHaveAnyMessageWithKeyword($tag) {
 		$activities = $this->activityPage->getAllActivityMessageLists();
 		foreach ($activities as $activity) {
-			PHPUnit_Framework_Assert::assertNotContains($tag, $activity);
+			PHPUnit\Framework\Assert::assertNotContains($tag, $activity);
 		}
 	}
 
@@ -384,7 +384,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -394,7 +394,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	 */
 	public function theActivityListShouldBeEmpty() {
 		$activities = $this->activityPage->getAllActivityMessageLists();
-		PHPUnit_Framework_Assert::assertEmpty(
+		PHPUnit\Framework\Assert::assertEmpty(
 			$activities,
 			"Activity list was expected to be empty but was not"
 		);
@@ -434,7 +434,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -483,7 +483,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -512,7 +512,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex(
 			$index - 1
 		);
-		PHPUnit_Framework_Assert::assertEquals($message, $latestActivityMessage);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}
 
 	/**
@@ -536,7 +536,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 			\strtoupper($user[0]),
 			$user
 		);
-		PHPUnit_Framework_Assert::assertEquals($expectedMsg, $actualMsg);
+		PHPUnit\Framework\Assert::assertEquals($expectedMsg, $actualMsg);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/ActivityPage.php
+++ b/tests/acceptance/features/lib/ActivityPage.php
@@ -23,7 +23,7 @@
  */
 namespace Page;
 
-use PHPUnit_Framework_Assert;
+use PHPUnit\Framework\Assert;
 use Behat\Mink\Session;
 
 /**
@@ -62,7 +62,7 @@ class ActivityPage extends OwncloudPage {
 	 */
 	public function getActivityMessageOfIndex($index) {
 		$activities = $this->getAllActivityMessageLists();
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			$index,
 			$activities,
 			__METHOD__ .
@@ -105,7 +105,7 @@ class ActivityPage extends OwncloudPage {
 			'Antivirus' => 'files_antivirus',
 			'Files' => 'files'
 		];
-		PHPUnit_Framework_Assert::assertArrayHasKey(
+		Assert::assertArrayHasKey(
 			$activityType,
 			$activityFilters,
 			__METHOD__ .


### PR DESCRIPTION
This PR demonstrates that the `PHPUnit_Framework_Assert` changes are required to make unit tests pass with PHPUnit6. They also work with PHPUnit5 in PR #720 - so it is possible to merge that before or after PHPUnit6.