### PR TITLE
phpunit enable failOnRisky

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="../../tests/bootstrap.php"
 		 verbose="true"
+		 failOnRisky="true"
 		 failOnWarning="true"
 		 strict="true"
 		 timeoutForSmallTests="900"


### PR DESCRIPTION
PHPUnit6 reports more "risky" tests (that do not make any assertions).

Enable `failOnRisky` so that we know in CI if that happens.