### PR TITLE
Revert "use p() instead of echo"

### DIFF
--- a/templates/personal.php
+++ b/templates/personal.php
@@ -37,7 +37,7 @@ style('activity', 'settings');
 				</td>
 				<?php endforeach; ?>
 				<td class="activity_select_group" data-select-group="<?php p($activity) ?>">
-					<?php p($data['desc']); ?>
+					<?php print_unescaped($data['desc']); ?>
 				</td>
 			</tr>
 		<?php endforeach; ?>


### PR DESCRIPTION
#711 introduced regression on html rendering. This PR  reverts #711. 
Fixes #724 