### PR TITLE
Move user creation without skeleton to core

### DIFF
--- a/tests/acceptance/features/bootstrap/ActivityContext.php
+++ b/tests/acceptance/features/bootstrap/ActivityContext.php
@@ -91,19 +91,4 @@ class ActivityContext implements Context {
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
 	}
-
-	/**
-	 * @Given /^user "([^"]*)" has been created with default attributes and without skeleton files$/
-	 *
-	 * @param string $user
-	 *
-	 * @return void
-	 */
-	public function userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles($user) {
-		$this->featureContext->runOcc(["config:system:get skeletondirectory"]);
-		$path = \trim($this->featureContext->getStdOutOfOccCommand());
-		$this->featureContext->runOcc(["config:system:delete skeletondirectory"]);
-		$this->featureContext->userHasBeenCreatedWithDefaultAttributes($user);
-		$this->featureContext->runOcc(["config:system:set skeletondirectory --value $path"]);
-	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -255,7 +255,7 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		}
 		$avatarText = \strtoupper($user[0]);
 		//Need to add username initial at the beginning because if there is no avatar of the user then,
-		// the username initial is shown in the webUI
+		// the username initial is shown on the webui
 		$message = \sprintf($this->youSharedMsgFramework, $entry, $avatarText, $user);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
 		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);

--- a/tests/acceptance/features/webUIActivityCreateUpdate/createFilesFolder.feature
+++ b/tests/acceptance/features/webUIActivityCreateUpdate/createFilesFolder.feature
@@ -285,6 +285,6 @@ Feature: Created files/folders activities
   Scenario: Creating folders should be listed in the activity tab
     Given user "user0" has created folder "/Doc1"
     When the user browses to the files page
-    And the user opens the file action menu of folder "Doc1" in the webUI
-    And the user clicks the details file action in the webUI
+    And the user opens the file action menu of folder "Doc1" on the webui
+    And the user clicks the details file action on the webui
     Then the activity number 1 should contain message "You created Doc1" in the activity tab

--- a/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
@@ -297,8 +297,8 @@ Feature: Sharing file/folders activities
     When the user browses directly to display the details of file "block-aligned.txt" in folder "/"
     Then the activity number 1 should have message saying that the file is shared with user "User One" in the activity tab
     And the activity number 2 should contain message "You created block-aligned.txt" in the activity tab
-    When the user opens the file action menu of folder "folder with space" in the webUI
-    And the user clicks the details file action in the webUI
+    When the user opens the file action menu of folder "folder with space" on the webui
+    And the user clicks the details file action on the webui
     Then the activity number 1 should have message saying that the folder is shared with user "User Two" in the activity tab
     And the activity number 2 should contain message "You created folder with space" in the activity tab
 
@@ -309,8 +309,8 @@ Feature: Sharing file/folders activities
     And user "user1" has logged in using the webUI
     When the user browses directly to display the details of file "block-aligned.txt" in folder "/"
     Then the activity number 1 should have message saying that the file is shared by user "User Zero" in the activity tab
-    When the user opens the file action menu of folder "folder with space" in the webUI
-    And the user clicks the details file action in the webUI
+    When the user opens the file action menu of folder "folder with space" on the webui
+    And the user clicks the details file action on the webui
     Then the activity number 1 should have message saying that the folder is shared by user "User Zero" in the activity tab
 
   @issue-695


### PR DESCRIPTION
## Description
- Move user creation without skeleton method from activity app to the core.
- Change 'in the webUI' to 'on the webUI' to match core change PR https://github.com/owncloud/core/pull/35375

## Related Issue
https://github.com/owncloud/QA/issues/621

## Motivation and Context
- Make CI faster in scenarios where there is no need for user files.

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>

:notebook: This will only pass after https://github.com/owncloud/core/pull/35355 is merged.