### PR TITLE
Handle no longer existing groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [2.4.2] - 2019-02-13
 
+- Handle no longer existing groups - [#738](https://github.com/owncloud/activity/pull/738)
+
 ### Fixed
 
 - Properly identify user from federation instance in activity entries, requires core 10.1.0 to work - [#672](https://github.com/owncloud/activity/pull/672)

--- a/lib/Formatter/GroupFormatter.php
+++ b/lib/Formatter/GroupFormatter.php
@@ -41,7 +41,10 @@ class GroupFormatter implements IFormatter {
 	 */
 	public function format(IEvent $event, $parameter) {
 		$group = $this->groupManager->get($parameter);
-		$displayName = $group->getDisplayName();
+		$displayName = $parameter;
+		if ($group !== null) {
+			$displayName = $group->getDisplayName();
+		}
 		return '<parameter>' . Util::sanitizeHTML($displayName) . '</parameter>';
 	}
 }

--- a/tests/Unit/Formatter/GroupFormatterTest.php
+++ b/tests/Unit/Formatter/GroupFormatterTest.php
@@ -51,8 +51,9 @@ class GroupFormatterTest extends TestCase {
 
 	public function dataFormat() {
 		return [
-			['para<m>eter1', '<parameter>para&lt;m&gt;eter1</parameter>'],
-			['para<m>eter2', '<parameter>para&lt;m&gt;eter2</parameter>'],
+			['para<m>eter1', '<parameter>display:para&lt;m&gt;eter1</parameter>'],
+			['para<m>eter2', '<parameter>display:para&lt;m&gt;eter2</parameter>'],
+			['unknown', '<parameter>unknown</parameter>', false],
 		];
 	}
 
@@ -62,20 +63,23 @@ class GroupFormatterTest extends TestCase {
 	 * @param string $parameter
 	 * @param string $expected
 	 */
-	public function testFormat($parameter, $expected) {
+	public function testFormat($parameter, $expected, $groupKnown = true) {
 		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
 		$event = $this->getMockBuilder('OCP\Activity\IEvent')
 			->disableOriginalConstructor()
 			->getMock();
 
 		$formatter = $this->getFormatter();
-		$group = $this->createMock(IGroup::class);
+		$group = null;
+		if ($groupKnown) {
+			$group = $this->createMock(IGroup::class);
+			$group->expects($this->once())
+				->method('getDisplayName')
+				->willReturn("display:$parameter");
+		}
 		$this->groupManager->expects($this->once())
 			->method('get')
 			->willReturn($group);
-		$group->expects($this->once())
-			->method('getDisplayName')
-			->willReturn($parameter);
 
 		$this->assertSame($expected, $formatter->format($event, $parameter));
 	}


### PR DESCRIPTION
### Steps to reproduce
1. Create group A
2. Have activities with group A (share a file afaik)
3. Delete group B
4. load activities
5. BEFORE: http status 500 and exception in log
6. AFTER: no error - activity is displayed