### PR TITLE
Add acceptance tests for checking activity relating to users and groups that don't exist

### DIFF
--- a/tests/acceptance/features/apiActivity/list.feature
+++ b/tests/acceptance/features/apiActivity/list.feature
@@ -378,3 +378,44 @@ Feature: List activity
       | typeicon         | /^icon-shared$/     |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
       | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <collection><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=parent.txt" id=\"\d+\">parent.txt<\/file><\/collection> with you$/|
+
+  Scenario: users checks a group related activity after deleting the group
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And group "grp1" has been created
+    And user "user0" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    When the administrator deletes group "grp1" using the provisioning API
+    Then the activity number 1 of user "user1" should match these properties:
+      | type             | /^shared$/          |
+      | user             | /^user0$/           |
+      | affecteduser     | /^user1$/           |
+      | app              | /^files_sharing$/   |
+      | subject          | /^shared_with_by$/  |
+      | object_name      | /^\/textfile0.txt$/ |
+      | object_type      | /^files$/           |
+      | typeicon         | /^icon-shared$/     |
+      | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
+      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
+
+  Scenario: users checks a user related activity after deleting the user
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    When the administrator deletes user "user0" using the provisioning API
+    Then the activity number 1 of user "user1" should match these properties:
+      | type             | /^shared$/          |
+      | user             | /^user0$/           |
+      | affecteduser     | /^user1$/           |
+      | app              | /^files_sharing$/   |
+      | subject          | /^shared_with_by$/  |
+      | object_name      | /^\/textfile0.txt$/ |
+      | object_type      | /^files$/           |
+      | typeicon         | /^icon-shared$/     |
+      | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
+      | subject_prepared | /^<user display-name=\"user0\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|

--- a/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
@@ -324,3 +324,27 @@ Feature: Sharing file/folders activities
     Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User Two"
     #remove the above step when issue is fixed
     #Then the activity number 1 should contain message "You shared textfile0.txt with User One and User Two" in the activity page
+
+  Scenario: users checks a group related activity after deleting the group
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And group "grp1" has been created
+    And user "user0" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    And group "grp1" has been deleted
+    And user "user0" has logged in using the webUI
+    When the user browses to the activity page
+    Then the activity number 1 should contain message "You shared textfile0.txt with group grp1" in the activity page
+
+
+  Scenario: users checks a user related activity after deleting the user
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And user "user1" has been deleted
+    And user "user0" has logged in using the webUI
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "user1"


### PR DESCRIPTION
Add  API and WebUI tests for checking the activities of user and groups that don't exist anymore.


Related issue #740