### PR TITLE
URL Formatter

### DIFF
--- a/lib/Formatter/UrlFormatter.php
+++ b/lib/Formatter/UrlFormatter.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author Benedikt Kulmann <b@kulmann.biz>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Activity\Formatter;
+
+use OCP\Activity\IEvent;
+use OCP\Util;
+
+class UrlFormatter implements IFormatter {
+
+	/**
+	 * Format a list of url parameters into an html a-tag. The parameters have to be provided as json encoded data, i.e. a string.
+	 * Allowed values are:
+	 * <ul>
+	 * <li>url - required value. Needs to be an absolute url, as relative urls can't be used in e.g. emails.</li>
+	 * <li>name - optional (fallback is the url). Can't be html (will be sanitized).</li>
+	 * <li>target - optional, but has to be out of ['_self', '_blank', '_parent', '_top'].</li>
+	 * </ul>
+	 *
+	 * @param IEvent $event
+	 * @param string $parameter The parameter to be formatted. In this case a list of parameters, separated by commas.
+	 *
+	 * @return string The formatted parameter
+	 */
+	public function format(IEvent $event, $parameter) {
+		$params = \json_decode($parameter, true);
+		if (!isset($params['url'])) {
+			// we can't work without a url
+			return '';
+		}
+		$url = $params['url'];
+		if (\preg_match('#https?://#', $url) !== 1) {
+			// we need an absolute url
+			return '';
+		}
+		$name = $url;
+		if (isset($params['name'])) {
+			$name = Util::sanitizeHTML($params['name']);
+		}
+		$target = false;
+		if (isset($params['target']) && \in_array($params['target'], ['_self', '_blank', '_parent', '_top'])) {
+			$target = $params['target'];
+		}
+		$link = '<a href="' . $url . '"';
+		if ($target !== false) {
+			$link .= ' target="' . $target . '"';
+		}
+		$link .= '>' . $name . '</a>';
+		return '<parameter>' . $link . '</parameter>';
+	}
+}

--- a/lib/Parameter/Factory.php
+++ b/lib/Parameter/Factory.php
@@ -26,6 +26,7 @@ use OCA\Activity\Formatter\GroupFormatter;
 use OCA\Activity\Formatter\IFormatter;
 use OCA\Activity\Formatter\CloudIDFormatter;
 use OCA\Activity\Formatter\FileFormatter;
+use OCA\Activity\Formatter\UrlFormatter;
 use OCA\Activity\Formatter\UserFormatter;
 use OCA\Activity\ViewInfoCache;
 use OCP\Activity\IEvent;
@@ -137,6 +138,8 @@ class Factory {
 			return new CloudIDFormatter($this->contactsManager);
 		} elseif ($formatter === 'group') {
 			return new GroupFormatter($this->groupManager);
+		} elseif ($formatter === 'url') {
+			return new UrlFormatter();
 		} else {
 			return new BaseFormatter();
 		}

--- a/tests/Unit/Formatter/UrlFormatterTest.php
+++ b/tests/Unit/Formatter/UrlFormatterTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author Benedikt Kulmann <b@kulmann.biz>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Activity\Tests\Formatter;
+
+use OCA\Activity\Formatter\IFormatter;
+use OCA\Activity\Formatter\UrlFormatter;
+use OCA\Activity\Tests\Unit\TestCase;
+use OCP\Activity\IEvent;
+
+class UrlFormatterTest extends TestCase {
+
+	/**
+	 * @param array $methods
+	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	public function getFormatter(array $methods = []) {
+		if (empty($methods)) {
+			return new UrlFormatter();
+		} else {
+			return $this->getMockBuilder(UrlFormatter::class)
+				->setConstructorArgs([])
+				->setMethods($methods)
+				->getMock();
+		}
+	}
+
+	public function dataFormat() {
+		return [
+			'empty parameter list' => ['', ''],
+			'no url but name given' => [
+				\json_encode(['name' => 'ownCloud']),
+				''
+			],
+			'invalid url given' => [
+				\json_encode(['url' => 'this is no url']),
+				''
+			],
+			'relative url given' => [
+				\json_encode(['url' => '/relative/url']),
+				''
+			],
+			'url as only parameter' => [
+				\json_encode(['url' => 'https://owncloud.com/']),
+				'<parameter><a href="https://owncloud.com/">https://owncloud.com/</a></parameter>'
+			],
+			'url and name' => [
+				\json_encode(['url' => 'https://owncloud.com/', 'name' => 'ownCloud']),
+				'<parameter><a href="https://owncloud.com/">ownCloud</a></parameter>'
+			],
+			'url, name and invalid target' => [
+				\json_encode(['url' => 'https://owncloud.com/', 'name' => 'ownCloud', 'target' => 'invalid']),
+				'<parameter><a href="https://owncloud.com/">ownCloud</a></parameter>'
+			],
+			'url, name and valid target' => [
+				\json_encode(['url' => 'https://owncloud.com/', 'name' => 'ownCloud', 'target' => '_blank']),
+				'<parameter><a href="https://owncloud.com/" target="_blank">ownCloud</a></parameter>'
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataFormat
+	 *
+	 * @param string $parameter
+	 * @param string $expected
+	 */
+	public function testFormat($parameter, $expected) {
+		/** @var \OCP\Activity\IEvent|\PHPUnit\Framework\MockObject\MockObject $event */
+		$event = $this->getMockBuilder(IEvent::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$formatter = $this->getFormatter();
+		$this->assertSame($expected, $formatter->format($event, $parameter));
+	}
+}


### PR DESCRIPTION
The idea of this issue https://github.com/owncloud/customer_portal/issues/411 was, to be able to notify Case owners in customer portal, when users uploaded files to case data folder. The notification needs context, so we wanted to add links to the Case details page and the Account details page. This is not possible with the `BaseFormatter`, as we can't inject a link into the href attribute of a prebuilt a-tag (url gets surrounded with a `strong`-tag). Injecting the complete a-tag is not possible as well, because the BaseFormatter sanitizes HTML.

This PR adds a URL Formatter, which expects an associative array, json encoded, to fulfill the parameter type `string` of `$parameters`, and converts it into an `a`-tag. Keys of the array can be `url`, `name` and `target`. `url` is required, `name` is recommended (so that the links don't look bad). Ideas for improvements are very welcome.

Our notification now looks like this (with fake data of course):
<img width="1168" alt="Bildschirmfoto 2019-06-23 um 11 17 55" src="https://user-images.githubusercontent.com/3532843/60006614-1c31b000-9671-11e9-8847-855358c3bbe9.png">