### PR TITLE
Acceptance test for deleting/restoring files by sharer and sharee and checking activity

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -78,6 +78,7 @@ default:
         - WebUILoginContext:
         - WebUIPersonalGeneralSettingsContext:
         - WebUISharingContext:
+        - TrashbinContext:
 
     webUIActivityTags:
       paths:

--- a/tests/acceptance/features/apiActivity/list.feature
+++ b/tests/acceptance/features/apiActivity/list.feature
@@ -433,3 +433,160 @@ Feature: List activity
       | typeicon         | /^icon-shared$/     |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
       | subject_prepared | /^<user display-name=\"user0\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
+
+  @skipOnOcV10.2
+  Scenario: Sharer and sharee check activity after sharer deletes shared file
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has shared file "/lorem.txt" with user "user1"
+    When user "user0" deletes file "/lorem.txt" using the WebDAV API
+    Then the activity number 1 of user "user0" should match these properties:
+      | type             | /^file_deleted$/      |
+      | user             | /^user0$/             |
+      | affecteduser     | /^user0$/             |
+      | app              | /^files$/             |
+      | subject          | /^deleted_self$/      |
+      | object_name      | /^\/lorem.txt$/       |
+      | object_type      | /^files$/             |
+      | typeicon         | /^icon-delete-color$/ |
+      | subject_prepared | /^You deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem\.txt\.d\d+&view=trashbin\" id=\"\d+\">lorem\.txt<\/file>$/ |
+    And the activity number 2 of user "user0" should match these properties:
+      | type             | /^shared$/               |
+      | user             | /^user0$/                |
+      | affecteduser     | /^user0$/                |
+      | app              | /^files_sharing$/        |
+      | subject          | /^shared_user_self$/     |
+      | object_name      | /^\/lorem.txt$/          |
+      | object_type      | /^files$/                |
+      | typeicon         | /^icon-shared$/          |
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\.d\d+&view=trashbin\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
+    And the activity number 1 of user "user1" should match these properties:
+      | type             | /^file_deleted$/         |
+      | user             | /^user0$/                |
+      | affecteduser     | /^user1$/                |
+      | app              | /^files$/                |
+      | subject          | /^deleted_by$/           |
+      | object_name      | /^\/lorem.txt$/          |
+      | object_type      | /^files$/                |
+      | typeicon         | /^icon-delete-color$/    |
+      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
+    And the activity number 2 of user "user1" should match these properties:
+      | type             | /^shared$/            |
+      | user             | /^user0$/             |
+      | affecteduser     | /^user1$/             |
+      | app              | /^files_sharing$/     |
+      | subject          | /^shared_with_by$/    |
+      | object_name      | /^\/lorem.txt$/       |
+      | object_type      | /^files$/             |
+      | typeicon         | /^icon-shared$/       |
+      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|
+
+  @skipOnOcV10.2
+  Scenario: Sharer and sharee check activity after sharee deletes shared file
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has shared file "/lorem.txt" with user "user1"
+    When user "user1" deletes file "/lorem.txt" using the WebDAV API
+    Then the activity number 1 of user "user0" should match these properties:
+      | type             | /^shared$/               |
+      | user             | /^user0$/                |
+      | affecteduser     | /^user0$/                |
+      | app              | /^files_sharing$/        |
+      | subject          | /^shared_user_self$/     |
+      | object_name      | /^\/lorem.txt$/          |
+      | object_type      | /^files$/                |
+      | typeicon         | /^icon-shared$/          |
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
+    And the activity number 1 of user "user1" should match these properties:
+      | type             | /^shared$/             |
+      | user             | /^user1$/              |
+      | affecteduser     | /^user1$/              |
+      | app              | /^files_sharing$/      |
+      | subject          | /^unshared_from_self$/ |
+      | typeicon         | /^icon-shared$/    |
+      | subject_prepared | /^You unshared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id="">lorem.txt<\/file> shared by <user display-name=\"User Zero\">user0<\/user> from self$/|
+    And the activity number 2 of user "user1" should match these properties:
+      | type             | /^shared$/            |
+      | user             | /^user0$/             |
+      | affecteduser     | /^user1$/             |
+      | app              | /^files_sharing$/     |
+      | subject          | /^shared_with_by$/    |
+      | object_name      | /^\/lorem.txt$/       |
+      | object_type      | /^files$/             |
+      | typeicon         | /^icon-shared$/       |
+      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|
+
+  @skipOnOcV10.2
+  Scenario: Sharer and sharee check activity after sharer deletes shared file and then again restore it
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has shared file "/lorem.txt" with user "user1"
+    When user "user0" deletes file "/lorem.txt" using the WebDAV API
+    And user "user0" restores the file with original path "lorem.txt" using the trashbin API
+    Then the activity number 1 of user "user0" should match these properties:
+      | type             | /^file_restored$/     |
+      | user             | /^user0$/             |
+      | affecteduser     | /^user0$/             |
+      | app              | /^files$/             |
+      | subject          | /^restored_self$/     |
+      | object_name      | /^\/lorem.txt$/       |
+      | object_type      | /^files$/             |
+      | subject_prepared | /^You restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem\.txt\" id=\"\d+\">lorem\.txt<\/file>$/ |
+    And the activity number 2 of user "user0" should match these properties:
+      | type             | /^file_deleted$/      |
+      | user             | /^user0$/             |
+      | affecteduser     | /^user0$/             |
+      | app              | /^files$/             |
+      | subject          | /^deleted_self$/      |
+      | object_name      | /^\/lorem.txt$/       |
+      | object_type      | /^files$/             |
+      | typeicon         | /^icon-delete-color$/ |
+      | subject_prepared | /^You deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem\.txt\" id=\"\d+\">lorem\.txt<\/file>$/ |
+    And the activity number 3 of user "user0" should match these properties:
+      | type             | /^shared$/               |
+      | user             | /^user0$/                |
+      | affecteduser     | /^user0$/                |
+      | app              | /^files_sharing$/        |
+      | subject          | /^shared_user_self$/     |
+      | object_name      | /^\/lorem.txt$/          |
+      | object_type      | /^files$/                |
+      | typeicon         | /^icon-shared$/          |
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
+    And the activity number 1 of user "user1" should match these properties:
+      | type             | /^file_restored$/     |
+      | user             | /^user0$/             |
+      | affecteduser     | /^user1$/             |
+      | app              | /^files$/             |
+      | subject          | /^restored_by$/     |
+      | object_name      | /^\/lorem.txt$/       |
+      | object_type      | /^files$/             |
+      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
+    And the activity number 2 of user "user1" should match these properties:
+      | type             | /^file_deleted$/         |
+      | user             | /^user0$/                |
+      | affecteduser     | /^user1$/                |
+      | app              | /^files$/                |
+      | subject          | /^deleted_by$/           |
+      | object_name      | /^\/lorem.txt$/          |
+      | object_type      | /^files$/                |
+      | typeicon         | /^icon-delete-color$/    |
+      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
+    And the activity number 3 of user "user1" should match these properties:
+      | type             | /^shared$/            |
+      | user             | /^user0$/             |
+      | affecteduser     | /^user1$/             |
+      | app              | /^files_sharing$/     |
+      | subject          | /^shared_with_by$/    |
+      | object_name      | /^\/lorem.txt$/       |
+      | object_type      | /^files$/             |
+      | typeicon         | /^icon-shared$/       |
+      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -70,6 +70,11 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	/**
 	 * @var string
 	 */
+	private $youUnSharedMsgFramework = "You unshared %s shared by %s%s from self";
+
+	/**
+	 * @var string
+	 */
 	private $sharedWithYouMsgFramework = "%s%s shared %s with you";
 
 	/**
@@ -257,6 +262,28 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 		//Need to add username initial at the beginning because if there is no avatar of the user then,
 		// the username initial is shown on the webui
 		$message = \sprintf($this->youSharedMsgFramework, $entry, $avatarText, $user);
+		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
+		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
+	}
+
+	/**
+	 * @When the activity number :index should have a message saying that you have unshared file/folder :entry shared by :user from self
+	 *
+	 * @param integer $index (starting from 1, newest to the oldest)
+	 * @param string $entry
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theActivityNumberShouldHaveAMessageSayingUnsharedFileFromSelf(
+		$index,
+		$entry,
+		$user
+	) {
+		$avatarText = \strtoupper($user[0]);
+		//Need to add username initial at the beginning because if there is no avatar of the user then,
+		// the username initial is shown on the webui
+		$message = \sprintf($this->youUnSharedMsgFramework, $entry, $avatarText, $user);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
 		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);
 	}

--- a/tests/acceptance/features/webUIActivityDeleteRestore/delete.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/delete.feature
@@ -146,3 +146,34 @@ Feature: Deleted files/folders activities
     When the user disables activity log stream for "file_deleted" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "deleted"
+
+  Scenario: Sharer and sharee check activity after sharer deletes shared file
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And the user has reloaded the current page of the webUI
+    When the user deletes file "textfile0.txt" using the webUI
+    And the user browses to the activity page
+    Then the activity number 1 should contain message "You deleted textfile0.txt" in the activity page
+    And the activity number 2 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+    When the user re-logs in as "user1" using the webUI
+    And the user browses to the activity page
+    Then the activity number 1 should contain message "User Zero deleted textfile0.txt" in the activity page
+    And the activity number 2 should have a message saying that user "User Zero" has shared "textfile0.txt" with you
+
+  @skipOnOcV10.2
+  Scenario: Sharer and sharee check activity after sharee deletes shared file
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And the user re-logs in as "user1" using the webUI
+    When the user deletes file "textfile0.txt" using the webUI
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "User Zero" from self
+    And the activity number 2 should contain message "User Zero shared textfile0.txt with you" in the activity page
+    When the user re-logs in as "user0" using the webUI
+    And the user browses to the activity page
+    And the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+

--- a/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
@@ -247,3 +247,36 @@ Feature: Restored files/folders activities
     When the user browses directly to display the details of file "lorem.txt" in folder "/"
     Then the activity number 1 should have message "You restored lorem.txt" in the activity tab
     And the activity number 2 should have message "You deleted lorem.txt" in the activity tab
+
+  Scenario: Sharer and sharee check activity after sharer deletes shared file and then again restore it
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And the user has reloaded the current page of the webUI
+    And user "user0" has deleted file "textfile0.txt"
+    And user "user0" has restored the file with original path "textfile0.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should contain message "You restored textfile0.txt" in the activity page
+    And the activity number 2 should contain message "You deleted textfile0.txt" in the activity page
+    And the activity number 3 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+    When the user re-logs in as "user1" using the webUI
+    And the user browses to the activity page
+    Then the activity number 1 should contain message "User Zero restored textfile0.txt" in the activity page
+    And the activity number 2 should contain message "User Zero deleted textfile0.txt" in the activity page
+    And the activity number 3 should have a message saying that user "User Zero" has shared "textfile0.txt" with you
+
+  Scenario: Sharer and sharee check activity after sharee deletes shared file and then again restore it
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And the user re-logs in as "user1" using the webUI
+    And user "user1" has deleted file "textfile0.txt"
+    And user "user0" has restored the file with original path "textfile0.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "User Zero" from self
+    And the activity number 2 should contain message "User Zero shared textfile0.txt with you" in the activity page
+    When the user re-logs in as "user0" using the webUI
+    When the user browses to the activity page
+    And the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User One"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add acceptance tests for:

- deleting a shared file/folder and check activity on both sides.
- deleting a shared file/folder, restore on each side, and check activity on both sides

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/activity/issues/747

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)