### PR TITLE
Adjust test steps because of core 35926

### DIFF
--- a/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
@@ -248,7 +248,7 @@ Feature: Restored files/folders activities
     Then the activity number 1 should have message "You restored lorem.txt" in the activity tab
     And the activity number 2 should have message "You deleted lorem.txt" in the activity tab
 
-  Scenario: Sharer and sharee check activity after sharer deletes shared file and then again restore it
+  Scenario: Sharer and sharee check activity after sharer deletes a shared file and then restores it
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
@@ -266,17 +266,34 @@ Feature: Restored files/folders activities
     And the activity number 2 should contain message "User Zero deleted textfile0.txt" in the activity page
     And the activity number 3 should have a message saying that user "User Zero" has shared "textfile0.txt" with you
 
-  Scenario: Sharer and sharee check activity after sharee deletes shared file and then again restore it
+  Scenario: Sharer and sharee check activity after sharee unshares a shared file
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | user1    |
     And user "user0" has shared file "textfile0.txt" with user "user1"
     And the user re-logs in as "user1" using the webUI
-    And user "user1" has deleted file "textfile0.txt"
-    And user "user0" has restored the file with original path "textfile0.txt"
+    And user "user1" has unshared file "textfile0.txt"
     When the user browses to the activity page
     Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "User Zero" from self
     And the activity number 2 should contain message "User Zero shared textfile0.txt with you" in the activity page
     When the user re-logs in as "user0" using the webUI
     And the user browses to the activity page
     Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+
+  Scenario: Sharer and sharee check activity after sharee deletes a shared file and then restores it
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And the user re-logs in as "user1" using the webUI
+    And user "user1" has deleted file "simple-folder/lorem.txt"
+    And user "user1" has restored the file with original path "simple-folder/lorem.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should contain message "You restored lorem.txt" in the activity page
+    And the activity number 2 should contain message "You deleted lorem.txt" in the activity page
+    And the activity number 3 should contain message "User Zero shared simple-folder with you" in the activity page
+    When the user re-logs in as "user0" using the webUI
+    And the user browses to the activity page
+    Then the activity number 1 should contain message "User One restored lorem.txt" in the activity page
+    And the activity number 2 should contain message "User One deleted lorem.txt" in the activity page
+    And the activity number 3 should have a message saying that you have shared folder "simple-folder" with user "User One"

--- a/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
@@ -266,20 +266,6 @@ Feature: Restored files/folders activities
     And the activity number 2 should contain message "User Zero deleted textfile0.txt" in the activity page
     And the activity number 3 should have a message saying that user "User Zero" has shared "textfile0.txt" with you
 
-  Scenario: Sharer and sharee check activity after sharee unshares a shared file
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | user1    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And the user re-logs in as "user1" using the webUI
-    And user "user1" has unshared file "textfile0.txt"
-    When the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "User Zero" from self
-    And the activity number 2 should contain message "User Zero shared textfile0.txt with you" in the activity page
-    When the user re-logs in as "user0" using the webUI
-    And the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User One"
-
   Scenario: Sharer and sharee check activity after sharee deletes a shared file and then restores it
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
@@ -33,14 +33,14 @@ Feature: public link sharing file/folders activities
   Scenario: Downloading a public shared file from a webUI should be listed in the activity list
     Given the user has created a new public link for file "textfile0.txt" using the webUI
     And the public accesses the last created public link using the webUI
-    When the public downloads the last created file using the webUI
+    When the public downloads all the shared data using the webUI
     And the user browses to the activity page
     Then the activity number 1 should contain message "Public shared file textfile0.txt was downloaded" in the activity page
 
   Scenario: Downloading a public shared folder from a webUI should be listed in the activity list
     Given the user has created a new public link for folder "simple-folder" using the webUI
     And the public accesses the last created public link using the webUI
-    When the public downloads the last created folder using the webUI
+    When the public downloads all the shared data using the webUI
     And the user browses to the activity page
     Then the activity number 1 should contain message "Public shared folder simple-folder was downloaded" in the activity page
 
@@ -68,7 +68,7 @@ Feature: public link sharing file/folders activities
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "public_links" using the webUI
     And the public accesses the last created public link using the webUI
-    And the public downloads the last created file using the webUI
+    And the public downloads all the shared data using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "downloaded"
     And the activity number 1 should contain message "You shared textfile0.txt via link" in the activity page
@@ -78,7 +78,7 @@ Feature: public link sharing file/folders activities
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "public_links" using the webUI
     And the public accesses the last created public link using the webUI
-    And the public downloads the last created folder using the webUI
+    And the public downloads all the shared data using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "downloaded"
     And the activity number 1 should contain message "You shared simple-folder via link" in the activity page

--- a/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
@@ -255,7 +255,7 @@ Feature: Sharing file/folders activities
     And the user browses to the activity page
     Then the activity number 1 should have a message saying that user "User One" created "newFolder"
 
-  Scenario: Deleting a share by a sharer should be listed in the activity list of the sharer
+  Scenario: Deleting a share by a sharer should be listed in the activity list of the sharee
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has shared folder "simple-folder" with user "user1"
     And user "user1" has logged in using the webUI
@@ -286,6 +286,7 @@ Feature: Sharing file/folders activities
     And user "user1" has deleted the last share
     And the user browses to the activity page
     Then the activity number 1 should have a message saying that "User One" removed the share of "User One" for "simple-folder"
+
   Scenario: Sharing a file/folder with a user should be listed in the activity tab of the sharer for the file
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
@@ -337,7 +338,6 @@ Feature: Sharing file/folders activities
     And user "user0" has logged in using the webUI
     When the user browses to the activity page
     Then the activity number 1 should contain message "You shared textfile0.txt with group grp1" in the activity page
-
 
   Scenario: users checks a user related activity after deleting the user
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
@@ -287,6 +287,20 @@ Feature: Sharing file/folders activities
     And the user browses to the activity page
     Then the activity number 1 should have a message saying that "User One" removed the share of "User One" for "simple-folder"
 
+  Scenario: Sharer and sharee check activity after sharee unshares a shared file
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+    And user "user0" has shared file "textfile0.txt" with user "user1"
+    And user "user1" has logged in using the webUI
+    And user "user1" has unshared file "textfile0.txt"
+    When the user browses to the activity page
+    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "User Zero" from self
+    And the activity number 2 should contain message "User Zero shared textfile0.txt with you" in the activity page
+    When the user re-logs in as "user0" using the webUI
+    And the user browses to the activity page
+    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+
   Scenario: Sharing a file/folder with a user should be listed in the activity tab of the sharer for the file
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |

--- a/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
@@ -287,6 +287,7 @@ Feature: Sharing file/folders activities
     And the user browses to the activity page
     Then the activity number 1 should have a message saying that "User One" removed the share of "User One" for "simple-folder"
 
+  @issue-752 @skipOnOcV10.2
   Scenario: Sharer and sharee check activity after sharee unshares a shared file
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
Issue #752 

- adjust test step text to match what changed in core (1st commit)
- adjust "delete-restore" and "unshare" test scenarios to do more correct stuff and pass. The problem with `restore.feature:269` started to be actually reported as a fail because of extra checks added to core `TrashbinContext` `restoreElement` (2nd and 3rd commit)
- skip the moved scenario on OcV10.2 (we can investigate later, let's get the passing things merged)
