### PR TITLE
Always use testrunner for acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ pipeline:
       - make vendor-bin-deps
     when:
       matrix:
-        USE_RELEASE_TARBALL: true
+        TEST_SUITE_TYPE: acceptance
 
   install-fed-server:
     image: owncloudci/core
@@ -75,14 +75,8 @@ pipeline:
     pull: true
     commands:
       - chown www-data /var/www/owncloud -R
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ];
-        then
-        chmod 777 /var/www/owncloud/server/testrunner/tests/acceptance/filesForUpload -R;
-        chmod +x /var/www/owncloud/server/testrunner/tests/acceptance/run.sh;
-        else
-        chmod 777 /var/www/owncloud/server/tests/acceptance/filesForUpload -R;
-        chmod +x /var/www/owncloud/server/tests/acceptance/run.sh;
-        fi
+      - chmod 777 /var/www/owncloud/server/testrunner/tests/acceptance/filesForUpload -R;
+      - chmod +x /var/www/owncloud/server/testrunner/tests/acceptance/run.sh;
     when:
       matrix:
         NEED_SERVER: true
@@ -124,7 +118,7 @@ pipeline:
       - TEST_SERVER_URL=http://server
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/server/testrunner/apps/activity; fi
+      - cd /var/www/owncloud/server/testrunner/apps/activity
       - make test-acceptance-api
     when:
       matrix:
@@ -143,7 +137,7 @@ pipeline:
     commands:
       - touch /var/www/owncloud/saved-settings.sh
       - . /var/www/owncloud/saved-settings.sh
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/server/testrunner/apps/activity; fi
+      - cd /var/www/owncloud/server/testrunner/apps/activity
       - make test-acceptance-webui
     when:
       matrix:
@@ -314,6 +308,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityComments
       DB_TYPE: mysql
@@ -324,6 +319,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityCreateUpdate
       DB_TYPE: mysql
@@ -334,6 +330,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityDeleteRestore
       DB_TYPE: mysql
@@ -344,6 +341,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingExternal
       DB_TYPE: mysql
@@ -356,6 +354,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingInternal
       DB_TYPE: mysql
@@ -368,6 +367,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityTags
       DB_TYPE: mysql
@@ -378,6 +378,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       OC_VERSION: daily-master-qa
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiActivity
       DB_TYPE: mysql
@@ -389,6 +390,7 @@ matrix:
     # Acceptance tests against latest stable release tarball.
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityComments
       DB_TYPE: mysql
@@ -396,10 +398,10 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityCreateUpdate
       DB_TYPE: mysql
@@ -407,10 +409,10 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityDeleteRestore
       DB_TYPE: mysql
@@ -418,10 +420,10 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingExternal
       DB_TYPE: mysql
@@ -431,10 +433,10 @@ matrix:
       NEED_INSTALL_APP: true
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-master-qa
-      USE_RELEASE_TARBALL: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivitySharingInternal
       DB_TYPE: mysql
@@ -444,10 +446,10 @@ matrix:
       NEED_INSTALL_APP: true
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-master-qa
-      USE_RELEASE_TARBALL: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: web-acceptance
       BEHAT_SUITE: webUIActivityTags
       DB_TYPE: mysql
@@ -455,10 +457,10 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true
 
     - PHP_VERSION: 7.1
       OC_VERSION: 10.2.1
+      TEST_SUITE_TYPE: acceptance
       TEST_SUITE: api-acceptance
       BEHAT_SUITE: apiActivity
       DB_TYPE: mysql
@@ -466,4 +468,3 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
-      USE_RELEASE_TARBALL: true

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
@@ -25,7 +25,7 @@ Feature: public link sharing file/folders activities
   @issue-690
   Scenario: Downloading a file from a public shared folder using API should be listed in the activity list
     Given user "user1" has created a public link share of folder "simple-folder"
-    When the public downloads file "lorem.txt" from inside the last public shared folder using the old public WebDAV API with range "bytes=1-7" using the old public WebDAV API
+    When the public downloads file "lorem.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API
     And the user browses to the activity page
     Then the activity number 1 should contain message "You shared simple-folder via link" in the activity page
     #Then the activity number 1 should contain message "Public shared file lorem.txt was downloaded" in the activity page


### PR DESCRIPTION
Previously we have been:
1) using the QA tarball acceptance test code when testing the app with the `daily-master-qa` tarball.
2) using the latest core master acceptance test code cloned from git when testing the app with the `10.2.1` or other release tarballs.

This sometimes creates inconsistency when core test steps have been modified, added, deleted in git core master but the `daily-master-qa` tarball is out-of-date. In that case it can be difficult or impossible to make the app CI pass - because some gherkin step text needs to be one way for `daily-master-qa` and another way for git core master.

Actually we may as well just always use the "testrunner" logic no matter which core tarball is the system-under-test.