### PR TITLE
Update starlark code

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -461,6 +461,7 @@ def phptests(testType):
 		'extraServices': [],
 		'extraEnvironment': {},
 		'extraCommandsBeforeTestRun': [],
+		'extraApps': [],
 	}
 
 	if 'defaults' in config:
@@ -518,6 +519,7 @@ def phptests(testType):
 					},
 					'steps': [
 						installCore('daily-master-qa', db, False),
+						installExtraApps(phpVersion, params['extraApps']),
 						setupServerAndApp(phpVersion, params['logLevel']),
 						params['extraSetup'],
 						{
@@ -698,9 +700,9 @@ def acceptance():
 									},
 									owncloudLog('federated')
 								] if params['federatedServerNeeded'] else []) + [
+									installExtraApps(phpVersion, params['extraApps']),
 									setupServerAndApp(phpVersion, params['logLevel']),
 									owncloudLog('server'),
-									installExtraApps(phpVersion, params['extraApps']),
 									params['extraSetup'],
 									fixPermissions(phpVersion, params['federatedServerNeeded']),
 									({

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -81,7 +81,7 @@ def main(ctx):
 	return before + stages + after
 
 def beforePipelines():
-	return codestyle() + phpstan() + phan()
+	return codestyle() + jscodestyle() + phpstan() + phan()
 
 def stagePipelines():
 	jsPipelines = javascript()
@@ -165,6 +165,50 @@ def codestyle():
 				result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 			pipelines.append(result)
+
+	return pipelines
+
+def jscodestyle():
+	pipelines = []
+
+	if 'jscodestyle' not in config:
+		return pipelines
+
+	if type(config['jscodestyle']) == "bool":
+		if not config['jscodestyle']:
+			return pipelines
+
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'coding-standard-js',
+		'workspace' : {
+			'base': '/var/www/owncloud',
+			'path': 'server/apps/%s' % config['app']
+		},
+		'steps': [
+			{
+				'name': 'coding-standard-js',
+				'image': 'owncloudci/php:7.2',
+				'pull': 'always',
+				'commands': [
+					'make test-js-style'
+				]
+			}
+		],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/pull/**',
+				'refs/tags/**'
+			]
+		}
+	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	pipelines.append(result)
 
 	return pipelines
 

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -447,12 +447,15 @@ def phptests(testType):
 	if testType not in config:
 		return pipelines
 
+	errorFound = False
+
 	default = {
 		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],
 		'coverage': True,
+		'includeKeyInMatrixName': False,
 		'logLevel': '2',
 		'extraSetup': None,
 		'extraServices': [],
@@ -497,10 +500,18 @@ def phptests(testType):
 					command = 'make test-php-integration'
 
 			for db in params['databases']:
+				keyString = '-' + category if params['includeKeyInMatrixName'] else ''
+				name = '%s%s-php%s-%s' % (testType, keyString, phpVersion, db.replace(":", ""))
+				maxLength = 50
+				nameLength = len(name)
+				if nameLength > maxLength:
+					print("Error: generated phpunit stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
+					errorFound = True
+
 				result = {
 					'kind': 'pipeline',
 					'type': 'docker',
-					'name': '%s-php%s-%s' % (testType, phpVersion, db.replace(":", "")),
+					'name': name,
 					'workspace' : {
 						'base': '/var/www/owncloud',
 						'path': 'server/apps/%s' % config['app']
@@ -549,6 +560,9 @@ def phptests(testType):
 
 				pipelines.append(result)
 
+	if errorFound:
+		return False
+
 	return pipelines
 
 def acceptance():
@@ -556,6 +570,10 @@ def acceptance():
 
 	if 'acceptance' not in config:
 		return pipelines
+
+	if type(config['acceptance']) == "bool":
+		if not config['acceptance']:
+			return pipelines
 
 	errorFound = False
 
@@ -574,6 +592,7 @@ def acceptance():
 		'extraCommandsBeforeTestRun': [],
 		'extraApps': [],
 		'useBundledApp': False,
+		'includeKeyInMatrixName': False,
 	}
 
 	if 'defaults' in config:
@@ -609,7 +628,8 @@ def acceptance():
 
 							if isWebUI or isAPI or isCLI:
 								browserString = '' if browser == '' else '-' + browser
-								name = '%s-%s%s-%s-php%s' % (shortSuiteName, server.replace('daily-', '').replace('-qa', ''), browserString, db.replace(':', ''), phpVersion)
+								keyString = '-' + category if params['includeKeyInMatrixName'] else ''
+								name = '%s%s-%s%s-%s-php%s' % (shortSuiteName, keyString, server.replace('daily-', '').replace('-qa', ''), browserString, db.replace(':', ''), phpVersion)
 								maxLength = 50
 								nameLength = len(name)
 								if nameLength > maxLength:


### PR DESCRIPTION
- support code style for JavaScript
- move `installExtraApps` before `setupServerAndApp` because sometimes the app under test requires some other app to be installed first (e.g. `files_ldap_home` needs `user_ldap` to first be installed before it can be enabled successfully)
- support `extraApps` for `phpunit` (as well as for `acceptance`)
- allow the "category" key to optionally be used in the pipeline matrix name by setting `'includeKeyInMatrixName': True` - this allows the same test suite, or phpunit job to be run with some different other context, without causing duplicate pipeline matrix names.