### PR TITLE
Run acceptance tests against latest core release

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -580,7 +580,7 @@ def acceptance():
 	errorFound = False
 
 	default = {
-		'servers': ['daily-master-qa', '10.2.1'],
+		'servers': ['daily-master-qa', 'latest'],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.0'],
 		'databases': ['mariadb:10.2'],

--- a/.drone.yml
+++ b/.drone.yml
@@ -1093,7 +1093,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIComments-10.2.1-chrome-mariadb10.2-php7.0
+name: webUIComments-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1115,7 +1115,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -1208,7 +1208,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIComments-10.2.1-firefox-mariadb10.2-php7.0
+name: webUIComments-latest-firefox-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1230,7 +1230,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -1555,7 +1555,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUICreateUpdat-10.2.1-chrome-mariadb10.2-php7.0
+name: webUICreateUpdat-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1577,7 +1577,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -1670,7 +1670,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUICreateUpdat-10.2.1-firefox-mariadb10.2-php7.0
+name: webUICreateUpdat-latest-firefox-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1692,7 +1692,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2017,7 +2017,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIDelRestore-10.2.1-chrome-mariadb10.2-php7.0
+name: webUIDelRestore-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -2039,7 +2039,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2132,7 +2132,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUIDelRestore-10.2.1-firefox-mariadb10.2-php7.0
+name: webUIDelRestore-latest-firefox-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -2154,7 +2154,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2479,7 +2479,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISharingInt-10.2.1-chrome-mariadb10.2-php7.0
+name: webUISharingInt-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -2501,7 +2501,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2594,7 +2594,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISharingInt-10.2.1-firefox-mariadb10.2-php7.0
+name: webUISharingInt-latest-firefox-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -2616,7 +2616,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2941,7 +2941,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUITags-10.2.1-chrome-mariadb10.2-php7.0
+name: webUITags-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -2963,7 +2963,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -3056,7 +3056,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUITags-10.2.1-firefox-mariadb10.2-php7.0
+name: webUITags-latest-firefox-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3078,7 +3078,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -3483,7 +3483,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISharingExt-10.2.1-chrome-mariadb10.2-php7.0
+name: webUISharingExt-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3505,7 +3505,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -3523,7 +3523,7 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: 10.2.1
+    version: latest
 
 - name: configure-federation
   pull: always
@@ -3638,7 +3638,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISharingExt-10.2.1-firefox-mariadb10.2-php7.0
+name: webUISharingExt-latest-firefox-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3660,7 +3660,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -3678,7 +3678,7 @@ steps:
   image: owncloudci/core
   settings:
     core_path: /var/www/owncloud/federated
-    version: 10.2.1
+    version: latest
 
 - name: configure-federation
   pull: always
@@ -3899,7 +3899,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: apiActivity-10.2.1-mariadb10.2-php7.0
+name: apiActivity-latest-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -3921,7 +3921,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/activity
-    version: 10.2.1
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -4043,29 +4043,29 @@ depends_on:
 - phpunit-php7.3-mariadb10.2
 - webUIComments-master-chrome-mariadb10.2-php7.0
 - webUIComments-master-firefox-mariadb10.2-php7.0
-- webUIComments-10.2.1-chrome-mariadb10.2-php7.0
-- webUIComments-10.2.1-firefox-mariadb10.2-php7.0
+- webUIComments-latest-chrome-mariadb10.2-php7.0
+- webUIComments-latest-firefox-mariadb10.2-php7.0
 - webUICreateUpdat-master-chrome-mariadb10.2-php7.0
 - webUICreateUpdat-master-firefox-mariadb10.2-php7.0
-- webUICreateUpdat-10.2.1-chrome-mariadb10.2-php7.0
-- webUICreateUpdat-10.2.1-firefox-mariadb10.2-php7.0
+- webUICreateUpdat-latest-chrome-mariadb10.2-php7.0
+- webUICreateUpdat-latest-firefox-mariadb10.2-php7.0
 - webUIDelRestore-master-chrome-mariadb10.2-php7.0
 - webUIDelRestore-master-firefox-mariadb10.2-php7.0
-- webUIDelRestore-10.2.1-chrome-mariadb10.2-php7.0
-- webUIDelRestore-10.2.1-firefox-mariadb10.2-php7.0
+- webUIDelRestore-latest-chrome-mariadb10.2-php7.0
+- webUIDelRestore-latest-firefox-mariadb10.2-php7.0
 - webUISharingInt-master-chrome-mariadb10.2-php7.0
 - webUISharingInt-master-firefox-mariadb10.2-php7.0
-- webUISharingInt-10.2.1-chrome-mariadb10.2-php7.0
-- webUISharingInt-10.2.1-firefox-mariadb10.2-php7.0
+- webUISharingInt-latest-chrome-mariadb10.2-php7.0
+- webUISharingInt-latest-firefox-mariadb10.2-php7.0
 - webUITags-master-chrome-mariadb10.2-php7.0
 - webUITags-master-firefox-mariadb10.2-php7.0
-- webUITags-10.2.1-chrome-mariadb10.2-php7.0
-- webUITags-10.2.1-firefox-mariadb10.2-php7.0
+- webUITags-latest-chrome-mariadb10.2-php7.0
+- webUITags-latest-firefox-mariadb10.2-php7.0
 - webUISharingExt-master-chrome-mariadb10.2-php7.0
 - webUISharingExt-master-firefox-mariadb10.2-php7.0
-- webUISharingExt-10.2.1-chrome-mariadb10.2-php7.0
-- webUISharingExt-10.2.1-firefox-mariadb10.2-php7.0
+- webUISharingExt-latest-chrome-mariadb10.2-php7.0
+- webUISharingExt-latest-firefox-mariadb10.2-php7.0
 - apiActivity-master-mariadb10.2-php7.0
-- apiActivity-10.2.1-mariadb10.2-php7.0
+- apiActivity-latest-mariadb10.2-php7.0
 
 ...


### PR DESCRIPTION
Instead of specifying `10.2.1` we can specify `latest` core. The download servers point `latest` to the latest core release - currently `10.2.1` then it will "automagically" switch to `10.3.0` one day...

So we will not have to touch all the app repos when there is a new core release to run against.

Note: this is the "default" test matrix for our nightly CI - we test against daily core master tarball and against the latest core release tarball.

As a separate thing we can discuss how we can also automate testing against a test release tarball (e.g. currently 10.3.0RC1). In that case:
1) we currently do not have a constant "logical" link pointing to "current core test tarball"
2) there may not always be a "current core test tarball", so sometimes we may not need to run tests against that
3) but if we move to more frequent patch releases, then maybe (2) will not apply - and we can "always" have a "current core test tarball"
