### PR TITLE
separate installApp from setupServerAndApp in drone starlark

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -259,6 +259,7 @@ def phpstan():
 				},
 				'steps': [
 					installCore('daily-master-qa', 'sqlite', False),
+					installApp(phpVersion),
 					setupServerAndApp(phpVersion, params['logLevel']),
 					{
 						'name': 'phpstan',
@@ -399,6 +400,7 @@ def javascript():
 		},
 		'steps': [
 			installCore('daily-master-qa', 'sqlite', False),
+			installApp('7.0'),
 			setupServerAndApp('7.0', params['logLevel']),
 			params['extraSetup'],
 			{
@@ -519,6 +521,7 @@ def phptests(testType):
 					},
 					'steps': [
 						installCore('daily-master-qa', db, False),
+						installApp(phpVersion),
 						installExtraApps(phpVersion, params['extraApps']),
 						setupServerAndApp(phpVersion, params['logLevel']),
 						params['extraSetup'],
@@ -700,6 +703,7 @@ def acceptance():
 									},
 									owncloudLog('federated')
 								] if params['federatedServerNeeded'] else []) + [
+									installApp(phpVersion),
 									installExtraApps(phpVersion, params['extraApps']),
 									setupServerAndApp(phpVersion, params['logLevel']),
 									owncloudLog('server'),
@@ -995,15 +999,26 @@ def installExtraApps(phpVersion, extraApps):
 		'commands': commandArray
 	}
 
+def installApp(phpVersion):
+	if 'appInstallCommand' not in config:
+		return None
+
+	return {
+		'name': 'install-app-%s' % config['app'],
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'cd /var/www/owncloud/server/apps/%s' % config['app'],
+			config['appInstallCommand']
+		]
+	}
+
 def setupServerAndApp(phpVersion, logLevel):
 	return {
 		'name': 'setup-server-%s' % config['app'],
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
-		'commands': ([
-			'cd /var/www/owncloud/server/apps/%s' % config['app'],
-			config['appInstallCommand']
-		] if 'appInstallCommand' in config else []) + [
+		'commands': [
 			'cd /var/www/owncloud/server',
 			'php occ a:l',
 			'php occ a:e %s' % config['app'],


### PR DESCRIPTION
I adjusted the order for installing the app and extra apps. There is now an extra `installApp` step which installs the current app-under-test before doing `installExtraApps`. Then `setupServerAndApp` runs to setup any server settings, and to enable the app-under-test.

This is needed because if we `installExtraApps` early, before the app-under-test has had its install command executed, then a command like `php occ app:list` can fail, because one of the apps to be listed does not yet have all its dependencies etc.

The problem is only noticed if when the app-under-test has an `appInstallCommand` and there are also extra apps to install. It first was needed in the `firewall` app when testing `firewall` and `files_primary_s3` `scality` objectstore together.