### PR TITLE
Update drone starlark 20190928

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -991,7 +991,7 @@ def installExtraApps(phpVersion, extraApps):
 	for app, command in apps.items():
 		commandArray.append('git clone https://github.com/owncloud/%s.git /var/www/owncloud/testrunner/apps/%s' % (app, app))
 		commandArray.append('cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % app)
-		if (command != None):
+		if ((command != None) and (command != '')):
 			commandArray.append('cd /var/www/owncloud/server/apps/%s' % app)
 			commandArray.append(command)
 		commandArray.append('cd /var/www/owncloud/server')

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -257,10 +257,11 @@ def phpstan():
 					'base': '/var/www/owncloud',
 					'path': 'server/apps/%s' % config['app']
 				},
-				'steps': [
-					installCore('daily-master-qa', 'sqlite', False),
-					installApp(phpVersion),
-					setupServerAndApp(phpVersion, params['logLevel']),
+				'steps':
+					installCore('daily-master-qa', 'sqlite', False) +
+					installApp(phpVersion) +
+					setupServerAndApp(phpVersion, params['logLevel']) +
+				[
 					{
 						'name': 'phpstan',
 						'image': 'owncloudci/php:%s' % phpVersion,
@@ -330,8 +331,9 @@ def phan():
 					'base': '/var/www/owncloud',
 					'path': 'server/apps/%s' % config['app']
 				},
-				'steps': [
-					installCore('daily-master-qa', 'sqlite', False),
+				'steps':
+					installCore('daily-master-qa', 'sqlite', False) +
+				[
 					{
 						'name': 'phan',
 						'image': 'owncloudci/php:%s' % phpVersion,
@@ -398,10 +400,11 @@ def javascript():
 			'base': '/var/www/owncloud',
 			'path': 'server/apps/%s' % config['app']
 		},
-		'steps': [
-			installCore('daily-master-qa', 'sqlite', False),
-			installApp('7.0'),
-			setupServerAndApp('7.0', params['logLevel']),
+		'steps':
+			installCore('daily-master-qa', 'sqlite', False) +
+			installApp('7.0') +
+			setupServerAndApp('7.0', params['logLevel']) +
+		[
 			params['extraSetup'],
 			{
 				'name': 'js-tests',
@@ -519,11 +522,12 @@ def phptests(testType):
 						'base': '/var/www/owncloud',
 						'path': 'server/apps/%s' % config['app']
 					},
-					'steps': [
-						installCore('daily-master-qa', db, False),
-						installApp(phpVersion),
-						installExtraApps(phpVersion, params['extraApps']),
-						setupServerAndApp(phpVersion, params['logLevel']),
+					'steps':
+						installCore('daily-master-qa', db, False) +
+						installApp(phpVersion) +
+						installExtraApps(phpVersion, params['extraApps']) +
+						setupServerAndApp(phpVersion, params['logLevel']) +
+					[
 						params['extraSetup'],
 						{
 							'name': '%s-tests' % testType,
@@ -673,10 +677,10 @@ def acceptance():
 									'base': '/var/www/owncloud',
 									'path': 'testrunner/apps/%s' % config['app']
 								},
-								'steps': [
-									installCore(server, db, params['useBundledApp']),
-									installTestrunner(phpVersion, params['useBundledApp'])
-								] + ([
+								'steps':
+									installCore(server, db, params['useBundledApp']) +
+									installTestrunner(phpVersion, params['useBundledApp']) +
+								([
 									{
 										'name': 'install-federation',
 										'image': 'owncloudci/core',
@@ -702,13 +706,16 @@ def acceptance():
 										]
 									},
 									owncloudLog('federated')
-								] if params['federatedServerNeeded'] else []) + [
-									installApp(phpVersion),
-									installExtraApps(phpVersion, params['extraApps']),
-									setupServerAndApp(phpVersion, params['logLevel']),
+								] if params['federatedServerNeeded'] else []) +
+									installApp(phpVersion) +
+									installExtraApps(phpVersion, params['extraApps']) +
+									setupServerAndApp(phpVersion, params['logLevel']) +
+								[
 									owncloudLog('server'),
 									params['extraSetup'],
-									fixPermissions(phpVersion, params['federatedServerNeeded']),
+								] +
+									fixPermissions(phpVersion, params['federatedServerNeeded']) +
+								[
 									({
 										'name': 'acceptance-tests',
 										'image': 'owncloudci/php:%s' % phpVersion,
@@ -949,10 +956,10 @@ def installCore(version, db, useBundledApp):
 	if not useBundledApp:
 		stepDefinition['settings']['exclude'] = 'apps/%s' % config['app']
 
-	return stepDefinition
+	return [stepDefinition]
 
 def installTestrunner(phpVersion, useBundledApp):
-	return {
+	return [{
 		'name': 'install-testrunner',
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
@@ -966,12 +973,12 @@ def installTestrunner(phpVersion, useBundledApp):
 			'cd /var/www/owncloud/testrunner',
 			'make install-composer-deps vendor-bin-deps'
 		]
-	}
+	}]
 
 def installExtraApps(phpVersion, extraApps):
 	if type(extraApps) == "list":
 		if extraApps == []:
-			return None
+			return []
 		apps = {}
 		for app in extraApps:
 			apps[app] = None
@@ -992,18 +999,18 @@ def installExtraApps(phpVersion, extraApps):
 		commandArray.append('php occ a:e %s' % app)
 		commandArray.append('php occ a:l')
 
-	return {
+	return [{
 		'name': 'install-extra-apps',
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': commandArray
-	}
+	}]
 
 def installApp(phpVersion):
 	if 'appInstallCommand' not in config:
-		return None
+		return []
 
-	return {
+	return [{
 		'name': 'install-app-%s' % config['app'],
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
@@ -1011,10 +1018,10 @@ def installApp(phpVersion):
 			'cd /var/www/owncloud/server/apps/%s' % config['app'],
 			config['appInstallCommand']
 		]
-	}
+	}]
 
 def setupServerAndApp(phpVersion, logLevel):
-	return {
+	return [{
 		'name': 'setup-server-%s' % config['app'],
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
@@ -1027,10 +1034,10 @@ def setupServerAndApp(phpVersion, logLevel):
 			'php occ config:system:set trusted_domains 1 --value=server',
 			'php occ log:manage --level %s' % logLevel,
 		]
-	}
+	}]
 
 def fixPermissions(phpVersion, federatedServerNeeded):
-	return {
+	return [{
 		'name': 'fix-permissions',
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
@@ -1039,7 +1046,7 @@ def fixPermissions(phpVersion, federatedServerNeeded):
 		] + ([
 			'chown -R www-data /var/www/owncloud/federated'
 		] if federatedServerNeeded else [])
-	}
+	}]
 
 def owncloudLog(server):
 	return {


### PR DESCRIPTION
1) Some functions that return a "step" dictionary are returning `None` when the step is not needed. That is causing a problem when we move over to not generating `.drone.yml` locally but executing the starlark code directly in the drone server. The matrix entry ends up in the list, but gets "stuck" in the `pending` state.

Change the code so that these functions return an empty array `[]`, which can be "added" with other arrays of steps.

2) Handle empty command for installing app - when there are multiple `extraApps` to install, then one of the apps might have a command needed to install it, but other apps might not. So we need to be smarter and make sure to ignore doing the command when it is the empty string.