### PR TITLE
Fix default browsers for acceptance tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -689,12 +689,12 @@ def acceptance():
 			isAPI = suite.startswith('api')
 			isCLI = suite.startswith('cli')
 
-			if isAPI or isCLI:
-				default['browsers'] = ['']
-
 			params = {}
 			for item in default:
 				params[item] = matrix[item] if item in matrix else default[item]
+
+			if isAPI or isCLI:
+				params['browsers'] = ['']
 
 			for server in params['servers']:
 				for browser in params['browsers']:


### PR DESCRIPTION
When looping to generate pipeline entries for acceptance tests, if there were some `webUI` entries processed after `api`  or `cli` entries, and the `webUI` entry used just the default browser, then the default got overwritten with null when the `api` or `cli` test pipeline was processed. So the `webUI` did not specify a browser - which creates a problem!

The `default` settings  should be set up at the top of `acceptance()` and not modified in the loops.

(This was noticed when trying to do ransomware_protection which has a more complex variety of test scenarios with other apps and backend storage)