### PR TITLE
drone notify on failure

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -931,6 +931,10 @@ def notify():
 		'trigger': {
 			'ref': [
 				'refs/tags/**'
+			],
+			'status': [
+				'success',
+				'failure'
 			]
 		}
 	}


### PR DESCRIPTION
If a nightly build has failure, then nothing is being reported in rocketchat, because the pipelines stop once there is a failure. So the notify pipeline is never executed.

Adjust so that the notify pipeline will execute on both success and failure.