### PR TITLE
ensure currentUser always string in FilesHooks constructor

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -129,7 +129,7 @@ class Application extends App {
 				new View(''),
 				$server->getDatabaseConnection(),
 				$server->getURLGenerator(),
-				$currentUser
+				(string)$currentUser
 			);
 		});
 

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -64,7 +64,7 @@ class FilesHooks {
 	/** @var IURLGenerator */
 	protected $urlGenerator;
 
-	/** @var string|false */
+	/** @var string */
 	protected $currentUser;
 
 	/**
@@ -77,9 +77,9 @@ class FilesHooks {
 	 * @param View $view
 	 * @param IDBConnection $connection
 	 * @param IURLGenerator $urlGenerator
-	 * @param string|false $currentUser
+	 * @param string $currentUser
 	 */
-	public function __construct(IManager $manager, Data $activityData, UserSettings $userSettings, IGroupManager $groupManager, View $view, IDBConnection $connection, IURLGenerator $urlGenerator, $currentUser) {
+	public function __construct(IManager $manager, Data $activityData, UserSettings $userSettings, IGroupManager $groupManager, View $view, IDBConnection $connection, IURLGenerator $urlGenerator, string $currentUser) {
 		$this->manager = $manager;
 		$this->activityData = $activityData;
 		$this->userSettings = $userSettings;
@@ -91,7 +91,7 @@ class FilesHooks {
 	}
 
 	/**
-	 * @return string|false Current UserID if logged in, false otherwise
+	 * @return string Current UserID if logged in, empty string otherwise
 	 */
 	protected function getCurrentUser() {
 		return $this->currentUser;
@@ -102,7 +102,7 @@ class FilesHooks {
 	 * @param string $path Path of the file that has been created
 	 */
 	public function fileCreate($path) {
-		if ($this->getCurrentUser() !== false) {
+		if ($this->getCurrentUser() !== "") {
 			$this->addNotificationsForFileAction($path, Files::TYPE_SHARE_CREATED, 'created_self', 'created_by');
 		} else {
 			$this->addNotificationsForFileAction($path, Files::TYPE_SHARE_CREATED, '', 'created_public');

--- a/tests/Unit/FilesHooksTest.php
+++ b/tests/Unit/FilesHooksTest.php
@@ -125,7 +125,7 @@ class FilesHooksTest extends TestCase {
 	public function dataGetCurrentUser() {
 		return [
 			['user'],
-			[false],
+			[''],
 		];
 	}
 
@@ -142,7 +142,7 @@ class FilesHooksTest extends TestCase {
 	public function dataFileCreate() {
 		return [
 			['user', 'created_self', 'created_by'],
-			[false, '', 'created_public'],
+			['', '', 'created_public'],
 		];
 	}
 

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
@@ -20,7 +20,7 @@ Feature: public link sharing file/folders activities
       | permissions | create        |
     And the public has uploaded file "test.txt" with content "This is a test"
     When the user browses to the activity page
-    Then the activity number 1 should contain message "created test.txt" in the activity page
+    Then the activity number 1 should contain message "test.txt was created in a public folder" in the activity page
 
   @issue-690
   Scenario: Downloading a file from a public shared folder using API should be listed in the activity list


### PR DESCRIPTION
Currently, `$currentUser` value is `null` if the user not found. However, the class expects its value as `false` in this case. Because of that `fileCreate` method condition is not working properly.
The type conversion problem resolved, by ensuring `currentUser` value will be always a string.

Fixes https://github.com/owncloud/enterprise/issues/3554