### PR TITLE
Increase wait-for-it -t 120 for ceph and scality services

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1289,7 +1289,7 @@ def setupCeph(serviceParams):
 
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 60 ceph:80',
+		'wait-for-it -t 120 ceph:80',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
 		'cd /var/www/owncloud/server',
@@ -1317,7 +1317,7 @@ def setupScality(serviceParams):
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	createExtraBuckets = serviceParams['createExtraBuckets'] if 'createExtraBuckets' in serviceParams else False
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 60 scality:8000',
+		'wait-for-it -t 120 scality:8000',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
 		'cd /var/www/owncloud/server'


### PR DESCRIPTION
In the last week or so we are experiencing longer times for pulling docker images, like for databases and object storage. We adjusted the "standard" wait for database services to 120 seconds. And are doing similar in https://github.com/owncloud/update-testing/pull/28

`files_primary_s3`  had some examples today where the 60 second wait was not long enough. This has been adjusted in https://github.com/owncloud/files_primary_s3/pull/260/commits/ea888d8cdcbb612992272cdc380eb82ca67c9cad

Make the same change here in the activity app so that it has current starlark code. (This is the first app in alphabetical order and so is the place that I copy "latest" code from when needed)