### PR TITLE
Drop PHP 7.0 from drone CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -16,12 +16,11 @@ config = {
 	'phpunit': {
 		'allDatabases' : {
 			'phpVersions': [
-				'7.0',
+				'7.1',
 			]
 		},
 		'reducedDatabases' : {
 			'phpVersions': [
-				'7.1',
 				'7.2',
 				'7.3',
 			],
@@ -106,7 +105,7 @@ def codestyle():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 	}
 
 	if 'defaults' in config:
@@ -295,7 +294,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 	}
 
 	if 'defaults' in config:
@@ -367,7 +366,7 @@ def build():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'commands': [
 			'make dist'
 		],
@@ -492,13 +491,13 @@ def javascript():
 		},
 		'steps':
 			installCore('daily-master-qa', 'sqlite', False) +
-			installApp('7.0') +
-			setupServerAndApp('7.0', params['logLevel']) +
+			installApp('7.1') +
+			setupServerAndApp('7.1', params['logLevel']) +
 			params['extraSetup'] +
 		[
 			{
 				'name': 'js-tests',
-				'image': 'owncloudci/php:7.0',
+				'image': 'owncloudci/php:7.1',
 				'pull': 'always',
 				'environment': params['extraEnvironment'],
 				'commands': params['extraCommandsBeforeTestRun'] + [
@@ -545,7 +544,7 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],
@@ -712,7 +711,7 @@ def acceptance():
 	default = {
 		'servers': ['daily-master-qa', 'latest'],
 		'browsers': ['chrome'],
-		'phpVersions': ['7.0'],
+		'phpVersions': ['7.1'],
 		'databases': ['mariadb:10.2'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
@@ -1297,7 +1296,7 @@ def setupCeph(serviceParams):
 
 	return [{
 		'name': 'setup-ceph',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'./apps/files_primary_s3/tests/drone/create-bucket.sh',
@@ -1325,7 +1324,7 @@ def setupScality(serviceParams):
 
 	return [{
 		'name': 'setup-scality',
-		'image': 'owncloudci/php:7.0',
+		'image': 'owncloudci/php:7.1',
 		'pull': 'always',
 		'commands': setupCommands + ([
 			'php occ s3:create-bucket owncloud --accept-warning'


### PR DESCRIPTION
Because core has dropped PHP 7.0 support https://github.com/owncloud/core/pull/36290