### PR TITLE
Change phpunit strict to beStrictAboutOutputDuringTests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,14 +3,16 @@
 		 verbose="true"
 		 failOnRisky="true"
 		 failOnWarning="true"
-		 strict="true"
+		 beStrictAboutOutputDuringTests="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 >
-	<testsuite name='unit'>
-		<directory suffix='Test.php'>./tests/Unit</directory>
-	</testsuite>
+	<testsuites>
+		<testsuite name='unit'>
+			<directory suffix='Test.php'>./tests/Unit</directory>
+		</testsuite>
+	</testsuites>
 	<!-- filters for code coverage -->
 	<filter>
 		<whitelist>


### PR DESCRIPTION
Fixes #807 

And while we are here, it is nice to put the `testsuite` inside a `testsuites` section.
(that is required if there are multiple test suites to define, but currently optional if there is only 1 tes suite)