### PR TITLE
Minimize dev dependency install in drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1221,7 +1221,7 @@ def installTestrunner(phpVersion, useBundledApp):
 			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
 		] if not useBundledApp else []) + [
 			'cd /var/www/owncloud/testrunner',
-			'make install-composer-deps vendor-bin-deps'
+			'make install-composer-deps'
 		]
 	}]
 

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -34,7 +34,7 @@ use OCP\Activity\IExtension;
 class ApiTest extends TestCase {
 	protected $originalWEBROOT;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->originalWEBROOT = \OC::$WEBROOT;
@@ -78,7 +78,7 @@ class ApiTest extends TestCase {
 		}
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		$data = new Data(
 			$this->createMock('OCP\Activity\IManager'),
 			\OC::$server->getDatabaseConnection(),

--- a/tests/Unit/AppInfo/ApplicationTest.php
+++ b/tests/Unit/AppInfo/ApplicationTest.php
@@ -37,7 +37,7 @@ class ApplicationTest extends TestCase {
 	/** @var \OCP\AppFramework\IAppContainer */
 	protected $container;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 		$this->app = new Application();
 		$this->container = $this->app->getContainer();

--- a/tests/Unit/ConsumerTest.php
+++ b/tests/Unit/ConsumerTest.php
@@ -43,7 +43,7 @@ class ConsumerTest extends TestCase {
 	/** @var \OCA\Activity\UserSettings */
 	protected $userSettings;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 		$this->deleteTestActivities();
 
@@ -85,7 +85,7 @@ class ConsumerTest extends TestCase {
 			]));
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		$this->deleteTestActivities();
 		parent::tearDown();
 	}

--- a/tests/Unit/Controller/ActivitiesTest.php
+++ b/tests/Unit/Controller/ActivitiesTest.php
@@ -50,7 +50,7 @@ class ActivitiesTest extends TestCase {
 	/** @var Activities */
 	protected $controller;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->config = $this->getMockBuilder('OCP\IConfig')
@@ -73,7 +73,7 @@ class ActivitiesTest extends TestCase {
 		$this->overwriteService('AvatarManager', $this->avatarManager);
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->restoreService('AvatarManager');
 		parent::tearDown();
 	}

--- a/tests/Unit/Controller/FeedTest.php
+++ b/tests/Unit/Controller/FeedTest.php
@@ -54,7 +54,7 @@ class FeedTest extends TestCase {
 	/** @var Feed */
 	protected $controller;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->data = $this->getMockBuilder('OCA\Activity\Data')

--- a/tests/Unit/Controller/OCSEndPointTest.php
+++ b/tests/Unit/Controller/OCSEndPointTest.php
@@ -72,7 +72,7 @@ class OCSEndPointTest extends TestCase {
 	/** @var OCSEndPoint */
 	protected $controller;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->data = $this->getMockBuilder('OCA\Activity\Data')
@@ -113,7 +113,7 @@ class OCSEndPointTest extends TestCase {
 		$this->overwriteService('AvatarManager', $this->avatarManager);
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		$this->restoreService('AvatarManager');
 		parent::tearDown();
 	}

--- a/tests/Unit/Controller/SettingsTest.php
+++ b/tests/Unit/Controller/SettingsTest.php
@@ -62,7 +62,7 @@ class SettingsTest extends TestCase {
 	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
 	private $user;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->data = $this->getMockBuilder(Data::class)

--- a/tests/Unit/DataDeleteActivitiesTest.php
+++ b/tests/Unit/DataDeleteActivitiesTest.php
@@ -37,7 +37,7 @@ class DataDeleteActivitiesTest extends TestCase {
 	/** @var \OCA\Activity\Data */
 	protected $data;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$activities = [
@@ -71,7 +71,7 @@ class DataDeleteActivitiesTest extends TestCase {
 		);
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		$this->data->deleteActivities([
 			'type' => 'test',
 		]);

--- a/tests/Unit/DataHelperTest.php
+++ b/tests/Unit/DataHelperTest.php
@@ -34,7 +34,7 @@ class DataHelperTest extends TestCase {
 	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->originalWEBROOT = \OC::$WEBROOT;
@@ -57,7 +57,7 @@ class DataHelperTest extends TestCase {
 			->getMock();
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		\OC::$WEBROOT = $this->originalWEBROOT;
 		parent::tearDown();
 	}

--- a/tests/Unit/DataTest.php
+++ b/tests/Unit/DataTest.php
@@ -44,7 +44,7 @@ class DataTest extends TestCase {
 	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $session;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->activityLanguage = $activityLanguage = \OCP\Util::getL10N('activity', 'en');
@@ -67,7 +67,7 @@ class DataTest extends TestCase {
 		);
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		$this->restoreService('UserSession');
 		parent::tearDown();
 	}

--- a/tests/Unit/FilesHooksTest.php
+++ b/tests/Unit/FilesHooksTest.php
@@ -50,7 +50,7 @@ class FilesHooksTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\IURLGenerator */
 	protected $urlGenerator;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->activityManager = $this->getMockBuilder('OCP\Activity\IManager')

--- a/tests/Unit/Formatter/CloudIDFormatterTest.php
+++ b/tests/Unit/Formatter/CloudIDFormatterTest.php
@@ -29,7 +29,7 @@ class CloudIDFormatterTest extends TestCase {
 	/** @var \OCP\Contacts\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->contactsManager = $this->getMockBuilder('OCP\Contacts\IManager')

--- a/tests/Unit/Formatter/FileFormatterTest.php
+++ b/tests/Unit/Formatter/FileFormatterTest.php
@@ -35,7 +35,7 @@ class FileFormatterTest extends TestCase {
 	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->urlGenerator = $this->getMockBuilder('OCP\IURLGenerator')

--- a/tests/Unit/Formatter/UserFormatterTest.php
+++ b/tests/Unit/Formatter/UserFormatterTest.php
@@ -33,7 +33,7 @@ class UserFormatterTest extends TestCase {
 	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->userManager = $this->getMockBuilder('OCP\IUserManager')

--- a/tests/Unit/GroupHelperTest.php
+++ b/tests/Unit/GroupHelperTest.php
@@ -30,7 +30,7 @@ class GroupHelperTest extends TestCase {
 	/** @var \OCA\Activity\DataHelper|\PHPUnit\Framework\MockObject\MockObject */
 	protected $dataHelper;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->activityManager = $this->getMockBuilder('OCP\Activity\IManager')

--- a/tests/Unit/HooksDeleteUserTest.php
+++ b/tests/Unit/HooksDeleteUserTest.php
@@ -33,7 +33,7 @@ use OCP\Activity\IExtension;
  * @package OCA\Activity\Tests
  */
 class HooksDeleteUserTest extends TestCase {
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$activities = [
@@ -72,7 +72,7 @@ class HooksDeleteUserTest extends TestCase {
 		}
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		$data = new Data(
 			$this->createMock('\OCP\Activity\IManager'),
 			\OC::$server->getDatabaseConnection(),

--- a/tests/Unit/MailQueueHandlerTest.php
+++ b/tests/Unit/MailQueueHandlerTest.php
@@ -60,7 +60,7 @@ class MailQueueHandlerTest extends TestCase {
 	/** @var IUser */
 	protected $user3;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$user1Id = $this->getUniqueId('mailqueueuser1_');
@@ -142,7 +142,7 @@ class MailQueueHandlerTest extends TestCase {
 		);
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		$query = \OC::$server->getDatabaseConnection()->prepare('DELETE FROM `*PREFIX*activity_mq` WHERE `amq_timestamp` < 500');
 		$query->execute();
 

--- a/tests/Unit/Parameter/CollectionTest.php
+++ b/tests/Unit/Parameter/CollectionTest.php
@@ -28,7 +28,7 @@ class CollectionTest extends TestCase {
 	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	protected $l;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->l = $this->getMockBuilder('OCP\IL10N')

--- a/tests/Unit/Parameter/FactoryTest.php
+++ b/tests/Unit/Parameter/FactoryTest.php
@@ -50,7 +50,7 @@ class FactoryTest extends TestCase {
 	/** @var  \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->activityManager = $this->getMockBuilder('OCP\Activity\IManager')

--- a/tests/Unit/Parameter/ParameterTest.php
+++ b/tests/Unit/Parameter/ParameterTest.php
@@ -30,7 +30,7 @@ class ParameterTest extends TestCase {
 	/** @var \OCA\Activity\Formatter\IFormatter|\PHPUnit\Framework\MockObject\MockObject */
 	protected $formatter;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->event = $this->getMockBuilder('OCP\Activity\IEvent')

--- a/tests/Unit/PersonalTest.php
+++ b/tests/Unit/PersonalTest.php
@@ -34,7 +34,7 @@ class PersonalTest extends TestCase {
 	protected $panel;
 	protected $app;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->app = $this->getMockBuilder(Application::class)
 			->disableOriginalConstructor()

--- a/tests/Unit/Template/RssTest.php
+++ b/tests/Unit/Template/RssTest.php
@@ -25,7 +25,7 @@ use OCA\Activity\Tests\Unit\TestCase;
 use OCP\AppFramework\Http\TemplateResponse;
 
 class RssTest extends TestCase {
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 	}
 

--- a/tests/Unit/UserSettingsTest.php
+++ b/tests/Unit/UserSettingsTest.php
@@ -32,7 +32,7 @@ class UserSettingsTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$activityLanguage = \OCP\Util::getL10N('activity', 'en');
@@ -52,7 +52,7 @@ class UserSettingsTest extends TestCase {
 		));
 	}
 
-	protected function tearDown() {
+	protected function tearDown(): void {
 		parent::tearDown();
 	}
 

--- a/tests/Unit/ViewInfoCacheTest.php
+++ b/tests/Unit/ViewInfoCacheTest.php
@@ -31,7 +31,7 @@ class ViewInfoCacheTest extends TestCase {
 	/** @var \OCA\Activity\ViewInfoCache|\PHPUnit\Framework\MockObject\MockObject */
 	protected $infoCache;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->view = $this->getMockBuilder('OC\Files\View')

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "7.0.8"
+            "php": "7.1"
         }
     },
     "require": {
@@ -12,6 +12,8 @@
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
-        "symfony/translation": "^3.4"
+        "symfony/translation": "^3.4",
+        "guzzlehttp/guzzle": "^5.3",
+        "phpunit/phpunit": "^7.5"
     }
 }


### PR DESCRIPTION
1) In the acceptance tests we use `guzzle` and `phpunit` `Assert`. At the moment we "somewhat by accident" get them "for free" in core. (see https://github.com/owncloud/core/issues/36514 ) Install them with `behat` in `vendor-bin/behat` so that we have them "locally" when running acceptance tests. Then we will be able to remove that from core when we like.
2) In core the unit test infrastructure has been changed to move forward to the newer declarations of the `setUp` and `tearDown` classes with return type `void`. The app unit tests inherit from some core classes, so we have to make the matching changes here in the app. This will future-proof the tests ready for phpunit v8...
3) There is no need to install `vendor-bin-deps` in core of the testrunner. That is just a time-waste.