### PR TITLE
Bump PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/activity",
   "config" : {
     "platform": {
-      "php": "7.0.8"
+      "php": "7.1"
     }
   },
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fca6047bf6973d373cdef569390fbbc",
+    "content-hash": "c5dc92fef1a9c3895bc82f4bef935899",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.8"
+        "php": "7.1"
     }
 }


### PR DESCRIPTION
There are only dev dependencies for the tools in `vendor-bin` so we can bump the composer php version here from 7.0.8 to 7.1 without any effect on the app itself (i.e. the next release of the app is not necessarily required to drop PHP 7.0 support)