### PR TITLE
occ command to send all pending notifications

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
   <summary>Keep track of events with Activity stream and email notifications</summary>
   <description>
 The ownCloud Activity application enables users to not only get a summarized overview of all file and folder events in their ownCloud, but also to receive notifications for such via email. The user can configure their individual Activity preferences in their personal settings and can decide in detail which file or folder actions should be listed in the Activity stream (accessible via the app launcher) and also for which file or folder actions the users wants to receive email notifications.
-The bulk email notifications can either be sent out hourly, daily or weekly to fit the specific needs of the individual user. 
+The bulk email notifications can either be sent out hourly, daily or weekly to fit the specific needs of the individual user.
 
 From creation of new files or folders, to file or folder changes, updates, restores from trash bin, sharing activities, comments, tags and downloads from public share links - the ownCloud Activity app gathers all file or folder related actions in one place for the user to review.
 For users with lots of activity it is possible to limit the Activity stream to 'Favorites' in order to avoid noise. Furthermore the application provides filters to give users the means to maintain overview by reducing entries to relevant information.
@@ -43,4 +43,7 @@ Never again miss an important event related to content in ownCloud and always be
   <settings>
     <personal>OCA\Activity\PersonalPanel</personal>
   </settings>
+  <commands>
+    <command>OCA\Activity\Command\SendEmails</command>
+  </commands>
 </info>

--- a/lib/BackgroundJob/EmailNotification.php
+++ b/lib/BackgroundJob/EmailNotification.php
@@ -81,11 +81,20 @@ class EmailNotification extends TimedJob {
 		$this->isCLI = \OC::$CLI;
 	}
 
+	public function sendAll() {
+		$this->run(['sendAll' => true]);
+	}
+
 	protected function run($argument) {
-		// We don't use time() but "time() - 1" here, so we don't run into
-		// runtime issues later and delete emails, which were created in the
-		// same second, but were not collected for the emails.
-		$sendTime = \time() - 1;
+		if (isset($argument['sendAll']) && $argument['sendAll'] === true) {
+			// Flush all queue
+			$sendTime = PHP_INT_MAX;
+		} else {
+			// We don't use time() but "time() - 1" here, so we don't run into
+			// runtime issues later and delete emails, which were created in the
+			// same second, but were not collected for the emails.
+			$sendTime = \time() - 1;
+		}
 
 		if ($this->isCLI) {
 			do {

--- a/lib/Command/SendEmails.php
+++ b/lib/Command/SendEmails.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Activity\Command;
+
+use OCA\Activity\BackgroundJob\EmailNotification;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SendEmails extends Command {
+	/** @var EmailNotification */
+	private $emailNotification;
+
+	public function __construct(EmailNotification $emailNotification) {
+		parent::__construct();
+		$this->emailNotification = $emailNotification;
+	}
+
+	protected function configure() {
+		$this->setName('activity:send-emails')
+			->setDescription('Send all pending activity emails now');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 *
+	 * @return int|void
+	 */
+	public function execute(InputInterface $input, OutputInterface $output) {
+		$this->emailNotification->sendAll();
+	}
+}

--- a/lib/Command/SendEmails.php
+++ b/lib/Command/SendEmails.php
@@ -47,6 +47,8 @@ class SendEmails extends Command {
 	 * @return int|void
 	 */
 	public function execute(InputInterface $input, OutputInterface $output) {
-		$this->emailNotification->sendAll();
+		do {
+			$usersNotified = $this->emailNotification->sendAll();
+		} while ($usersNotified > 0);
 	}
 }

--- a/lib/Command/SendEmails.php
+++ b/lib/Command/SendEmails.php
@@ -21,18 +21,39 @@
 
 namespace OCA\Activity\Command;
 
-use OCA\Activity\BackgroundJob\EmailNotification;
+use OCA\Activity\MailQueueHandler;
+use OCP\IConfig;
+use OCP\ILogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SendEmails extends Command {
-	/** @var EmailNotification */
-	private $emailNotification;
+	const BATCH_SIZE = 250;
 
-	public function __construct(EmailNotification $emailNotification) {
+	/** @var MailQueueHandler */
+	private $mqHandler;
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var ILogger */
+	private $logger;
+
+	/**
+	 * SendEmails constructor.
+	 *
+	 * @param MailQueueHandler $mailQueueHandler
+	 * @param IConfig $config
+	 * @param ILogger $logger
+	 */
+	public function __construct(MailQueueHandler $mailQueueHandler,
+								   IConfig $config,
+								   ILogger $logger) {
 		parent::__construct();
-		$this->emailNotification = $emailNotification;
+		$this->mqHandler = $mailQueueHandler;
+		$this->config = $config;
+		$this->logger = $logger;
 	}
 
 	protected function configure() {
@@ -48,7 +69,59 @@ class SendEmails extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output) {
 		do {
-			$usersNotified = $this->emailNotification->sendAll();
+			$usersNotified = $this->sendBatch();
 		} while ($usersNotified > 0);
+	}
+
+	protected function sendBatch() {
+		$allUsers = $this->mqHandler->getAllUsers(self::BATCH_SIZE);
+		if (empty($allUsers)) {
+			// No users found to notify, mission abort
+			return 0;
+		}
+
+		$affectedUIDs = \array_map(function ($u) {
+			return $u['uid'];
+		}, $allUsers);
+		$userLanguages = $this->config->getUserValueForUsers('core', 'lang', $affectedUIDs);
+		$userTimezones = $this->config->getUserValueForUsers('core', 'timezone', $affectedUIDs);
+		$defaultLang = $this->config->getSystemValue('default_language', 'en');
+		$defaultTimeZone = \date_default_timezone_get();
+
+		$sentMailForUsers = [];
+		foreach ($allUsers as $user) {
+			$uid = $user['uid'];
+			if (empty($user['email'])) {
+				// The user did not setup an email address
+				// So we will not send an email but still discard the queue entries
+				$this->logger->debug("Couldn't send notification email to user '$uid' (email address isn't set for that user)", ['app' => 'activity']);
+				$sentMailForUsers[] = [
+					'uid' => $uid,
+					'maxMailId' => $user['max_mail_id']
+				];
+				continue;
+			}
+
+			try {
+				$language = (!empty($userLanguages[$uid])) ? $userLanguages[$uid] : $defaultLang;
+				$timezone = (!empty($userTimezones[$uid])) ? $userTimezones[$uid] : $defaultTimeZone;
+				$this->mqHandler->sendAllEmailsToUser($uid, $user['email'], $language, $timezone, $user['max_mail_id']);
+				$sentMailForUsers[] = [
+					'uid' => $uid,
+					'maxMailId' => $user['max_mail_id']
+				];
+			} catch (\Exception $e) {
+				// Delete all entries we dealt with
+				$this->mqHandler->deleteAllSentItems($sentMailForUsers);
+
+				// Throw the exception again - which gets logged by core and the job is handled appropriately
+				throw $e;
+			}
+		}
+
+		// Delete all entries we dealt with
+		$this->mqHandler->deleteAllSentItems($sentMailForUsers);
+
+		return \count($allUsers);
 	}
 }

--- a/lib/Parameter/Factory.php
+++ b/lib/Parameter/Factory.php
@@ -78,7 +78,7 @@ class Factory {
 								ViewInfoCache $infoCache,
 								IL10N $l,
 								IGroupManager $groupManager,
-								$user) {
+								$user = null) {
 		$this->activityManager = $activityManager;
 		$this->userManager = $userManager;
 		$this->urlGenerator = $urlGenerator;

--- a/tests/Unit/Command/SendEmailsTest.php
+++ b/tests/Unit/Command/SendEmailsTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Activity\Tests\Comand;
+
+use OCA\Activity\Command\SendEmails;
+use OCA\Activity\MailQueueHandler;
+use OCA\Activity\Tests\Unit\TestCase;
+use OCP\IConfig;
+use OCP\ILogger;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class SendEmailsTest
+ *
+ * @group DB
+ */
+class SendEmailsTest extends TestCase {
+	/** @var MailQueueHandler | \PHPUnit\Framework\MockObject\MockObject */
+	private $mqHandler;
+
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
+	private $config;
+
+	/** @var ILogger | \PHPUnit\Framework\MockObject\MockObject */
+	private $logger;
+
+	/** @var SendEmails */
+	private $sendEmails;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->mqHandler = $this->createMock(MailQueueHandler::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->sendEmails = new SendEmails($this->mqHandler, $this->config, $this->logger);
+	}
+
+	public function testSend() {
+		$this->mqHandler->method('getAllUsers')
+			->willReturnOnConsecutiveCalls(
+				[
+					[
+						'uid' => 'anon',
+						'email' => 'anon@im.org',
+						'max_mail_id' => 50,
+					]
+				],
+				[]
+			);
+		$this->mqHandler->expects($this->once())
+			->method('sendAllEmailsToUser')
+			->with('anon', 'anon@im.org', 'en', 'UTC', 50);
+		$this->mqHandler->expects($this->once())
+			->method('deleteAllSentItems')
+			->with([
+				['uid' => 'anon', 'maxMailId' => 50]
+			]);
+
+		$this->config->method('getUserValueForUsers')->willReturnOnConsecutiveCalls(
+				['anon' => 'en'],
+				['anon' => 'UTC']
+		);
+
+		$this->sendEmails->execute(
+			$this->createMock(InputInterface::class),
+			$this->createMock(OutputInterface::class)
+		);
+	}
+}

--- a/tests/Unit/MailQueueHandlerTest.php
+++ b/tests/Unit/MailQueueHandlerTest.php
@@ -354,6 +354,7 @@ class MailQueueHandlerTest extends TestCase {
 			$this->assertSame(0, $skipped);
 		}
 	}
+
 	public function testSendAllEmailsToUser() {
 		$maxTime = 200;
 		$user = $this->user2->getUID();


### PR DESCRIPTION
## Concept
- Create an occ command to send out all pending notifications instantly
- Don't touch existing code

## Implementation:
1,2,3 is repeated in batches of 250 until the count of notified users becomes 0.  

1. we get all uids and all max(mail_id)  per uid. (The queue could be changed when the sending in process so we have max mail_id to work with)
2. we iterate through uids sending an email containing all user notifications for actions with `mail_id <= max(mail_id)`
3. we delete all notifications in a one go as 
```
DELETE FROM *PREFIX*activity_mq WHERE
 (uid='uid1' AND mail_id<=max_mail_id_uid1)
 OR (uid='uid2' AND mail_id<=max_mail_id_uid2)
...
 OR (uid='uidN' AND mail_id<=max_mail_id_uidN)