### PR TITLE
Increase wait-for-db timeout from 120 to 600 seconds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1285,7 +1285,7 @@ def setupCeph(serviceParams):
 
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 120 ceph:80',
+		'wait-for-it -t 600 ceph:80',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
 		'cd /var/www/owncloud/server',
@@ -1313,7 +1313,7 @@ def setupScality(serviceParams):
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	createExtraBuckets = serviceParams['createExtraBuckets'] if 'createExtraBuckets' in serviceParams else False
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
-		'wait-for-it -t 120 scality:8000',
+		'wait-for-it -t 600 scality:8000',
 		'cd /var/www/owncloud/server/apps/files_primary_s3',
 		'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
 		'cd /var/www/owncloud/server'


### PR DESCRIPTION
## Description
The drone agents are sometimes taking "a long time" (tm) to pull docker images. In particular this is a problem when it takes a long time to pull the database image (mariadb, postgresql, oracle...). The `install-core` step waits 120 seconds for the database to become available. If the pull took more than 2 minutes, then we get a timeout in `install-core` and the pipeline fails. That means the whole build fails and it has to be started all over again. That is very annoying.

This is seen mostly first thing in the morning, when the autoscaler starts new drone agents. Specially if a lot of drone agents get started at a similar time, they seem to be slow to pull each docker image the first time. After that, they have the docker images cached, so later pulls of the docker images do not have this time delay.

Since we know there is a very variable delay here, set the timeout to a high value (10 minutes = 600 seconds). That will avoid annoying unnecessary fails, while still providing a reasonable time-to-failure in the rare case where the database really did fail on startup.

## Motivation and Context

## How Has This Been Tested?
CI
