### PR TITLE
wait for apache server to be up

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1315,9 +1315,11 @@ def fixPermissions(phpVersion, federatedServerNeeded):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'chown -R www-data /var/www/owncloud/server'
+			'chown -R www-data /var/www/owncloud/server',
+			'wait-for-it -t 600 server:80'
 		] + ([
-			'chown -R www-data /var/www/owncloud/federated'
+			'chown -R www-data /var/www/owncloud/federated',
+			'wait-for-it -t 600 federated:80'
 		] if federatedServerNeeded else [])
 	}]
 
@@ -1401,4 +1403,3 @@ def databaseServiceForFederation(db, suffix):
 			'MYSQL_ROOT_PASSWORD': getDbRootPassword()
 		}
 	}]
-	


### PR DESCRIPTION
We are sometimes seeing pipelines where we get all the way to the behat acceptance tests but the Apache server service has not yet started. Usually this is "random" slowness in pulling the needed image from docker... e.g.
https://drone.owncloud.com/owncloud/files_primary_s3/1429/130/17
```
curl: (6) Could not resolve host: server
Server on http://server is down or not working correctly.
Makefile:125: recipe for target 'test-acceptance-core-api' failed
```

After doing the fix-permissions `chown`, then wait for the server service to be reachable. This seems a logical place, because once we set those permissions on code for the server, any step after that will expect the Apache server to be functional.

This can be applied to other drone starlark in apps. Once this works here, I will apply first to the apps with a big number of pipelines - encryption, files_primary_s3 and user_ldap