### PR TITLE
Add a config option to send notifications ASAP

### DIFF
--- a/lib/Controller/Settings.php
+++ b/lib/Controller/Settings.php
@@ -122,7 +122,9 @@ class Settings extends Controller {
 		}
 
 		$email_batch_time = 3600;
-		if ($notify_setting_batchtime === UserSettings::EMAIL_SEND_DAILY) {
+		if ($notify_setting_batchtime === UserSettings::EMAIL_SEND_ASAP) {
+			$email_batch_time = 1;
+		} elseif ($notify_setting_batchtime === UserSettings::EMAIL_SEND_DAILY) {
 			$email_batch_time = 3600 * 24;
 		} elseif ($notify_setting_batchtime === UserSettings::EMAIL_SEND_WEEKLY) {
 			$email_batch_time = 3600 * 24 * 7;
@@ -179,7 +181,9 @@ class Settings extends Controller {
 
 		$settingBatchTime = UserSettings::EMAIL_SEND_HOURLY;
 		$currentSetting = (int) $this->userSettings->getUserSetting($this->user->getUID(), 'setting', 'batchtime');
-		if ($currentSetting === 3600 * 24 * 7) {
+		if ($currentSetting === 1) {
+			$settingBatchTime = UserSettings::EMAIL_SEND_ASAP;
+		} elseif ($currentSetting === 3600 * 24 * 7) {
 			$settingBatchTime = UserSettings::EMAIL_SEND_WEEKLY;
 		} elseif ($currentSetting === 3600 * 24) {
 			$settingBatchTime = UserSettings::EMAIL_SEND_DAILY;

--- a/lib/UserSettings.php
+++ b/lib/UserSettings.php
@@ -43,6 +43,7 @@ class UserSettings {
 	const EMAIL_SEND_HOURLY = 0;
 	const EMAIL_SEND_DAILY = 1;
 	const EMAIL_SEND_WEEKLY = 2;
+	const EMAIL_SEND_ASAP = 255;
 
 	/**
 	 * @param IManager $manager

--- a/templates/personal.php
+++ b/templates/personal.php
@@ -62,6 +62,7 @@ style('activity', 'settings');
 	<br />
 	<label for="notify_setting_batchtime"><?php p($l->t('Send emails:')); ?></label>
 	<select id="notify_setting_batchtime" name="notify_setting_batchtime">
+		<option value="255"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_ASAP): ?> selected="selected"<?php endif; ?>><?php p($l->t('As soon as possible')); ?></option>
 		<option value="0"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_HOURLY): ?> selected="selected"<?php endif; ?>><?php p($l->t('Hourly')); ?></option>
 		<option value="1"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_DAILY): ?> selected="selected"<?php endif; ?>><?php p($l->t('Daily')); ?></option>
 		<option value="2"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_WEEKLY): ?> selected="selected"<?php endif; ?>><?php p($l->t('Weekly')); ?></option>

--- a/tests/Unit/Controller/SettingsTest.php
+++ b/tests/Unit/Controller/SettingsTest.php
@@ -99,6 +99,7 @@ class SettingsTest extends TestCase {
 			[3600, false, false, 0, false, false],
 			[3600 * 24, true, false, 1, true, false],
 			[3600 * 24 * 7, false, true, 2, false, true],
+			[1, false, true, 255, false, true],
 		];
 	}
 
@@ -279,6 +280,7 @@ class SettingsTest extends TestCase {
 	public function displayPanelEmailSendBatchSettingData() {
 		return [
 			[0, 0, 'Hourly'],
+			[1, 255, 'As soon as possible'],
 			['foobar', 0, 'Hourly'],
 			[3600, 0, 'Hourly'],
 			[3600 * 24, 1, 'Daily'],


### PR DESCRIPTION
- Add a config option to send email notifications ASAP 
IRL it happens on the next `occ system:cron` invocation