### PR TITLE
Test with guzzle6

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -14,7 +14,7 @@
         "sensiolabs/behat-page-object-extension": "^2.0",
         "symfony/translation": "^3.4",
         "sabre/xml": "^2.1",
-        "guzzlehttp/guzzle": "^5.3",
+        "guzzlehttp/guzzle": "^6.5",
         "phpunit/phpunit": "^7.5"
     }
 }


### PR DESCRIPTION
~This is an example of running app acceptance tests with guzzle6. It uses the core acceptance test code in core branch `use-guzzle6-for-acceptance-tests` to demonstrate.

When that core PR gets merged, then we will need to do the first commit (bump guzzle to 6.5 in `vendor-bin/behat/composer.json`) in every app repo, because the apps use the core `master` acceptance test code for many steps. In particular the `Given` step that creates users! The code for that step is different in Guzzle6 and will not work from an app that tries to still use Guzzle5.~

See comment below - now this is just the needed change.