### PR TITLE
Skip disabled users and do not break the cronjob on the first unsent email

### DIFF
--- a/lib/BackgroundJob/EmailNotification.php
+++ b/lib/BackgroundJob/EmailNotification.php
@@ -68,25 +68,11 @@ class EmailNotification extends TimedJob {
 		// Run all 15 Minutes
 		$this->setInterval(15 * 60);
 
-		if ($mailQueueHandler === null || $config === null || $logger === null || $isCLI === null) {
-			$this->fixDIForJobs();
-		} else {
-			$this->mqHandler = $mailQueueHandler;
-			$this->userManager = $userManager;
-			$this->config = $config;
-			$this->logger = $logger;
-			$this->isCLI = $isCLI;
-		}
-	}
-
-	protected function fixDIForJobs() {
-		$application = new Application();
-
-		$this->mqHandler = $application->getContainer()->query('MailQueueHandler');
-		$this->userManager = \OC::$server->getUserManager();
-		$this->config = \OC::$server->getConfig();
-		$this->logger = \OC::$server->getLogger();
-		$this->isCLI = \OC::$CLI;
+		$this->mqHandler = $mailQueueHandler;
+		$this->userManager = $userManager;
+		$this->config = $config;
+		$this->logger = $logger;
+		$this->isCLI = $isCLI;
 	}
 
 	protected function run($argument) {

--- a/lib/BackgroundJob/EmailNotification.php
+++ b/lib/BackgroundJob/EmailNotification.php
@@ -142,10 +142,14 @@ class EmailNotification extends TimedJob {
 				$this->mqHandler->sendEmailToUser($uid, $user['email'], $language, $timezone, $sendTime);
 				$sentMailForUsers[] = $uid;
 			} catch (\Exception $e) {
-				// Run cleanup before we die
-				$this->mqHandler->deleteSentItems($sentMailForUsers, $sendTime);
-				// Throw the exception again - which gets logged by core and the job is handled appropriately
-				throw $e;
+				$this->logger->warning(
+					"Couldn't send notification email to user {user} ({reason}})",
+					[
+						'app' => 'activity',
+						'user' => $uid,
+						'reason' => $e->getMessage()
+					]
+				);
 			}
 		}
 

--- a/tests/Unit/BackgroundJob/EmailNotificationTest.php
+++ b/tests/Unit/BackgroundJob/EmailNotificationTest.php
@@ -128,8 +128,6 @@ class EmailNotificationTest extends TestCase {
 	 * Test run where all emails fail to send - cleanup should error
 	 */
 	public function testRunStepWhereEmailThrowsException() {
-		$this->expectException(\Exception::class);
-
 		$this->mqHandler->expects($this->any())
 			->method('getAffectedUsers')
 			->with(2, 200)
@@ -155,6 +153,8 @@ class EmailNotificationTest extends TestCase {
 		$fakeUser->expects($this->once())->method('isEnabled')
 			->willReturn(true);
 		$this->userManager->method('get')->willReturn($fakeUser);
+		$this->logger->expects($this->once())
+			->method('warning');
 
 		// Cleanup will be performed, but should now handle having no users supplied to it
 		// This deals with the case that the first email in the queue throws

--- a/tests/Unit/BackgroundJob/EmailNotificationTest.php
+++ b/tests/Unit/BackgroundJob/EmailNotificationTest.php
@@ -61,8 +61,7 @@ class EmailNotificationTest extends TestCase {
 	public function constructAndRunData() {
 		return [
 			[true],
-			[false],
-			[null],
+			[false]
 		];
 	}
 


### PR DESCRIPTION
- [x] we don't need to fix DI since https://github.com/owncloud/core/pull/21281
- [x] Do not try to send notification if the user is disabled
- [x] Keep on sending emails after the exception