### PR TITLE
Ignore .phpunit.result.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ nbproject
 /tests/coverage*
 /tests/acceptance/output*
 /tests/output
+.phpunit.result.cache
 node_modules
 vendor-bin/**/composer.lock
 vendor/


### PR DESCRIPTION
which is created when running phpunit v8 tests