### PR TITLE
Adjust drone pipelines for PHP 7.4

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -22,6 +22,7 @@ config = {
 		'reducedDatabases' : {
 			'phpVersions': [
 				'7.3',
+				'7.4',
 			],
 			'databases': [
 				'sqlite',
@@ -352,7 +353,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.2', '7.3'],
+		'phpVersions': ['7.2', '7.3', '7.4'],
 	}
 
 	if 'defaults' in config:
@@ -603,7 +604,7 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.2', '7.3'],
+		'phpVersions': ['7.2', '7.3', '7.4'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
 		],


### PR DESCRIPTION
- run some unit test pipelines with PHP 7.4 (as we do for 7.3)
- add PHP 7.4 to the default lists of PHP versions.