### PR TITLE
[Tests-Only] Use realistic Usernames

### DIFF
--- a/tests/acceptance/features/apiActivity/list.feature
+++ b/tests/acceptance/features/apiActivity/list.feature
@@ -4,12 +4,12 @@ Feature: List activity
   So that I know what is happening with my files/folders
 
   Scenario: file deletion should be listed in the activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" deletes file "textfile0.txt" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    When user "Alice" deletes file "textfile0.txt" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/textfile0.txt$/   |
@@ -20,14 +20,14 @@ Feature: List activity
   @skipOnOcV10.2
   Scenario: file restore should be listed in the activity list
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the file with original path "textfile0.txt" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has logged in to a web-style session
+    When user "Alice" restores the file with original path "textfile0.txt" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/   |
-      | user             | /^user0$/           |
-      | affecteduser     | /^user0$/           |
+      | user             | /^Alice$/           |
+      | affecteduser     | /^Alice$/           |
       | app              | /^files$/           |
       | subject          | /^restored_self$/   |
       | object_name      | /^\/textfile0.txt$/ |
@@ -35,12 +35,12 @@ Feature: List activity
       | subject_prepared | /^You restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0\.txt\" id=\"\d+\">textfile0\.txt<\/file>$/ |
 
   Scenario: folder deletion should be listed in the activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" deletes folder "FOLDER" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    When user "Alice" deletes folder "FOLDER" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/FOLDER$/          |
@@ -51,14 +51,14 @@ Feature: List activity
   @skipOnOcV10.2
   Scenario: folder restore should be listed in the activity list
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted folder "FOLDER"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the folder with original path "FOLDER" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has deleted folder "FOLDER"
+    And user "Alice" has logged in to a web-style session
+    When user "Alice" restores the folder with original path "FOLDER" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/ |
-      | user             | /^user0$/         |
-      | affecteduser     | /^user0$/         |
+      | user             | /^Alice$/         |
+      | affecteduser     | /^Alice$/         |
       | app              | /^files$/         |
       | subject          | /^restored_self$/ |
       | object_name      | /^\/FOLDER$/      |
@@ -66,12 +66,12 @@ Feature: List activity
       | subject_prepared | /^You restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/FOLDER\" id=\"\d+\">FOLDER<\/file>$/ |
 
   Scenario: file inside folder deletion should be listed in the activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" deletes file "PARENT/parent.txt" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    When user "Alice" deletes file "PARENT/parent.txt" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/         |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user0$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Alice$/                |
       | app              | /^files$/                |
       | subject          | /^deleted_self$/         |
       | object_name      | /^\/PARENT\/parent.txt$/ |
@@ -82,14 +82,14 @@ Feature: List activity
   @skipOnOcV10.2
   Scenario: file inside folder restore should be listed in the activity list
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted file "PARENT/parent.txt"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the file with original path "PARENT/parent.txt" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has deleted file "PARENT/parent.txt"
+    And user "Alice" has logged in to a web-style session
+    When user "Alice" restores the file with original path "PARENT/parent.txt" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/        |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user0$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Alice$/                |
       | app              | /^files$/                |
       | subject          | /^restored_self$/        |
       | object_name      | /^\/PARENT\/parent.txt$/ |
@@ -97,12 +97,12 @@ Feature: List activity
       | subject_prepared | /^You restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT&scrollto=parent\.txt\" id=\"\d+\">PARENT\/parent\.txt<\/file>$/ |
 
   Scenario: sub folder deletion should be listed in the activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" deletes folder "PARENT/CHILD" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    When user "Alice" deletes folder "PARENT/CHILD" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/PARENT\/CHILD$/   |
@@ -113,14 +113,14 @@ Feature: List activity
   @skipOnOcV10.2
   Scenario: sub folder restore should be listed in the activity list
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted folder "PARENT/CHILD"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the folder with original path "PARENT/CHILD" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has deleted folder "PARENT/CHILD"
+    And user "Alice" has logged in to a web-style session
+    When user "Alice" restores the folder with original path "PARENT/CHILD" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/   |
-      | user             | /^user0$/           |
-      | affecteduser     | /^user0$/           |
+      | user             | /^Alice$/           |
+      | affecteduser     | /^Alice$/           |
       | app              | /^files$/           |
       | subject          | /^restored_self$/   |
       | object_name      | /^\/PARENT\/CHILD$/ |
@@ -128,13 +128,13 @@ Feature: List activity
       | subject_prepared | /^You restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT\/CHILD" id=\"\d+\">PARENT\/CHILD<\/file>$/ |
 
   Scenario: multiple file deletion should be listed in activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" deletes file "textfile0.txt" using the WebDAV API
-    And user "user0" deletes file "textfile1.txt" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    When user "Alice" deletes file "textfile0.txt" using the WebDAV API
+    And user "Alice" deletes file "textfile1.txt" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/textfile1\.txt$/  |
@@ -143,13 +143,13 @@ Feature: List activity
       | subject_prepared | /^You deleted <collection><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile1\.txt\.d\d+&view=trashbin\" id=\"\d+\">textfile1\.txt<\/file><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0\.txt\.d\d+&view=trashbin\" id=\"\d+\">textfile0\.txt<\/file><\/collection>$/ |
 
   Scenario: multiple folder deletion should be listed in activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" deletes folder "PARENT" using the WebDAV API
-    And user "user0" deletes folder "FOLDER" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    When user "Alice" deletes folder "PARENT" using the WebDAV API
+    And user "Alice" deletes folder "FOLDER" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/FOLDER$/          |
@@ -160,16 +160,16 @@ Feature: List activity
   @skipOnOcV10.2
   Scenario: multiple file restore should be listed in activity list
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted file "textfile1.txt"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the file with original path "textfile0.txt" using the trashbin API
-    And user "user0" restores the file with original path "textfile1.txt" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted file "textfile1.txt"
+    And user "Alice" has logged in to a web-style session
+    When user "Alice" restores the file with original path "textfile0.txt" using the trashbin API
+    And user "Alice" restores the file with original path "textfile1.txt" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/    |
-      | user             | /^user0$/            |
-      | affecteduser     | /^user0$/            |
+      | user             | /^Alice$/            |
+      | affecteduser     | /^Alice$/            |
       | app              | /^files$/            |
       | subject          | /^restored_self$/    |
       | object_name      | /^\/textfile1\.txt$/ |
@@ -179,16 +179,16 @@ Feature: List activity
   @skipOnOcV10.2
   Scenario: multiple folder restore should be listed in activity list
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted folder "FOLDER"
-    And user "user0" has deleted folder "PARENT"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the folder with original path "FOLDER" using the trashbin API
-    And user "user0" restores the folder with original path "PARENT" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has deleted folder "FOLDER"
+    And user "Alice" has deleted folder "PARENT"
+    And user "Alice" has logged in to a web-style session
+    When user "Alice" restores the folder with original path "FOLDER" using the trashbin API
+    And user "Alice" restores the folder with original path "PARENT" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/ |
-      | user             | /^user0$/         |
-      | affecteduser     | /^user0$/         |
+      | user             | /^Alice$/         |
+      | affecteduser     | /^Alice$/         |
       | app              | /^files$/         |
       | subject          | /^restored_self$/ |
       | object_name      | /^\/PARENT$/      |
@@ -196,13 +196,13 @@ Feature: List activity
       | subject_prepared | /^You restored <collection><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT\" id=\"\d+\">PARENT<\/file><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/FOLDER\" id=\"\d+\">FOLDER<\/file><\/collection>$/ |
 
   Scenario: mix of folder and file deletion should be listed in activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" deletes file "textfile0.txt" using the WebDAV API
-    And user "user0" deletes folder "FOLDER" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    When user "Alice" deletes file "textfile0.txt" using the WebDAV API
+    And user "Alice" deletes folder "FOLDER" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/FOLDER$/          |
@@ -213,16 +213,16 @@ Feature: List activity
   @skipOnOcV10.2
   Scenario: mix of folder and file restore should be listed in activity list
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "FOLDER"
-    And user "user0" has logged in to a web-style session
-    When user "user0" restores the file with original path "textfile0.txt" using the trashbin API
-    And user "user0" restores the folder with original path "FOLDER" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "FOLDER"
+    And user "Alice" has logged in to a web-style session
+    When user "Alice" restores the file with original path "textfile0.txt" using the trashbin API
+    And user "Alice" restores the folder with original path "FOLDER" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/ |
-      | user             | /^user0$/         |
-      | affecteduser     | /^user0$/         |
+      | user             | /^Alice$/         |
+      | affecteduser     | /^Alice$/         |
       | app              | /^files$/         |
       | subject          | /^restored_self$/ |
       | object_name      | /^\/FOLDER$/      |
@@ -233,41 +233,41 @@ Feature: List activity
   Scenario: folder share should be listed in the activity list
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
-      | user0    |
-      | user1    |
-      | user2    |
-    When user "user0" creates folder "/one" using the WebDAV API
-    And user "user0" creates folder "/two" using the WebDAV API
-    And user "user0" shares folder "/one" with user "user1" using the sharing API
-    And user "user0" shares folder "/two" with user "user2" using the sharing API
-    Then the activity number 1 of user "user0" should match these properties:
+      | Alice    |
+      | Brian    |
+      | Carol    |
+    When user "Alice" creates folder "/one" using the WebDAV API
+    And user "Alice" creates folder "/two" using the WebDAV API
+    And user "Alice" shares folder "/one" with user "Brian" using the sharing API
+    And user "Alice" shares folder "/two" with user "Carol" using the sharing API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^shared$/           |
-      | user             | /^user0$/            |
-      | affecteduser     | /^user0$/            |
+      | user             | /^Alice$/            |
+      | affecteduser     | /^Alice$/            |
       | app              | /^files_sharing$/    |
       | subject          | /^shared_user_self$/ |
       | object_name      | /^\/two$/            |
       | object_type      | /^files$/            |
       | typeicon         | /^icon-shared$/      |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/two\" id=\"\d+\">two<\/file> with <user display-name=\"User Two\">user2<\/user>$/|
-    And the activity number 2 of user "user0" should match these properties:
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/two\" id=\"\d+\">two<\/file> with <user display-name=\"Carol King\">Carol<\/user>$/|
+    And the activity number 2 of user "Alice" should match these properties:
       | type             | /^shared$/           |
-      | user             | /^user0$/            |
-      | affecteduser     | /^user0$/            |
+      | user             | /^Alice$/            |
+      | affecteduser     | /^Alice$/            |
       | app              | /^files_sharing$/    |
       | subject          | /^shared_user_self$/ |
       | object_name      | /^\/one$/            |
       | object_type      | /^files$/            |
       | typeicon         | /^icon-shared$/      |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/one\" id=\"\d+\">one<\/file> with <user display-name=\"User One\">user1<\/user>$/|
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/one\" id=\"\d+\">one<\/file> with <user display-name=\"Brian Murphy\">Brian<\/user>$/|
 
   Scenario: folder creation should be listed in the activity list
-    Given user "user0" has been created with default attributes and without skeleton files
-    When user "user0" creates folder "/one" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When user "Alice" creates folder "/one" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_created$/   |
-      | user             | /^user0$/          |
-      | affecteduser     | /^user0$/          |
+      | user             | /^Alice$/          |
+      | affecteduser     | /^Alice$/          |
       | app              | /^files$/          |
       | subject          | /^created_self$/   |
       | object_name      | /^\/one$/          |
@@ -277,12 +277,12 @@ Feature: List activity
       | subject_prepared | /^You created <collection><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/one\" id=\"\d+\">one<\/file>/|
 
   Scenario: file upload should be listed in activity list
-     Given user "user0" has been created with default attributes and without skeleton files
-     When user "user0" uploads file "filesForUpload/textfile.txt" to "/text.txt" using the WebDAV API
-     Then the activity number 1 of user "user0" should match these properties:
+     Given user "Alice" has been created with default attributes and without skeleton files
+     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/text.txt" using the WebDAV API
+     Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_created$/   |
-      | user             | /^user0$/          |
-      | affecteduser     | /^user0$/          |
+      | user             | /^Alice$/          |
+      | affecteduser     | /^Alice$/          |
       | app              | /^files$/          |
       | subject          | /^created_self$/   |
       | object_name      | /^\/text.txt$/     |
@@ -293,308 +293,308 @@ Feature: List activity
 
   @skipOnOcV10.2
   Scenario: different files share with different user should be listed in activity list of sharer
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
-    When user "user0" shares file "PARENT/parent.txt" with user "user2" using the sharing API
-    And user "user0" shares file "textfile0.txt" with user "user1" using the sharing API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    When user "Alice" shares file "PARENT/parent.txt" with user "Carol" using the sharing API
+    And user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^shared$/           |
-      | user             | /^user0$/            |
-      | affecteduser     | /^user0$/            |
+      | user             | /^Alice$/            |
+      | affecteduser     | /^Alice$/            |
       | app              | /^files_sharing$/    |
       | subject          | /^shared_user_self$/ |
       | object_name      | /^\/textfile0.txt$/  |
       | object_type      | /^files$/            |
       | typeicon         | /^icon-shared$/      |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
-    And the activity number 2 of user "user0" should match these properties:
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with <user display-name=\"Brian Murphy\">Brian<\/user>$/|
+    And the activity number 2 of user "Alice" should match these properties:
       | type             | /^shared$/               |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user0$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Alice$/                |
       | app              | /^files_sharing$/        |
       | subject          | /^shared_user_self$/     |
       | object_name      | /^\/PARENT\/parent.txt$/ |
       | object_type      | /^files$/                |
       | typeicon         | /^icon-shared$/          |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT$/ |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT&scrollto=parent.txt" id=\"\d+\">PARENT\/parent.txt<\/file> with <user display-name=\"User Two\">user2<\/user>$/|
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT&scrollto=parent.txt" id=\"\d+\">PARENT\/parent.txt<\/file> with <user display-name=\"Carol King\">Carol<\/user>$/|
 
   @skipOnOcV10.2
   Scenario: different files shared with same user should be listed in activity list of sharer
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and without skeleton files
-    When user "user0" shares file "PARENT/parent.txt" with user "user1" using the sharing API
-    And user "user0" shares file "textfile0.txt" with user "user1" using the sharing API
-    Then the activity number 1 of user "user0" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    When user "Alice" shares file "PARENT/parent.txt" with user "Brian" using the sharing API
+    And user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^shared$/           |
-      | user             | /^user0$/            |
-      | affecteduser     | /^user0$/            |
+      | user             | /^Alice$/            |
+      | affecteduser     | /^Alice$/            |
       | app              | /^files_sharing$/    |
       | subject          | /^shared_user_self$/ |
       | object_name      | /^\/textfile0.txt$/  |
       | object_type      | /^files$/            |
       | typeicon         | /^icon-shared$/      |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
-    And the activity number 2 of user "user0" should match these properties:
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with <user display-name=\"Brian Murphy\">Brian<\/user>$/|
+    And the activity number 2 of user "Alice" should match these properties:
       | type             | /^shared$/               |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user0$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Alice$/                |
       | app              | /^files_sharing$/        |
       | subject          | /^shared_user_self$/     |
       | object_name      | /^\/PARENT\/parent.txt$/ |
       | object_type      | /^files$/                |
       | typeicon         | /^icon-shared$/          |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT$/ |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT&scrollto=parent.txt" id=\"\d+\">PARENT\/parent.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/PARENT&scrollto=parent.txt" id=\"\d+\">PARENT\/parent.txt<\/file> with <user display-name=\"Brian Murphy\">Brian<\/user>$/|
 
   @skipOnOcV10.2
   Scenario: different files shared with different user should be listed in activity list of sharee
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
-    When user "user0" shares file "PARENT/parent.txt" with user "user1" using the sharing API
-    And user "user0" shares file "textfile0.txt" with user "user2" using the sharing API
-    Then the activity number 1 of user "user2" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    When user "Alice" shares file "PARENT/parent.txt" with user "Brian" using the sharing API
+    And user "Alice" shares file "textfile0.txt" with user "Carol" using the sharing API
+    Then the activity number 1 of user "Carol" should match these properties:
       | type             | /^shared$/          |
-      | user             | /^user0$/           |
-      | affecteduser     | /^user2$/           |
+      | user             | /^Alice$/           |
+      | affecteduser     | /^Carol$/           |
       | app              | /^files_sharing$/   |
       | subject          | /^shared_with_by$/  |
       | object_name      | /^\/textfile0.txt$/ |
       | object_type      | /^files$/           |
       | typeicon         | /^icon-shared$/     |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
-    And the activity number 1 of user "user1" should match these properties:
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
+    And the activity number 1 of user "Brian" should match these properties:
       | type             | /^shared$/         |
-      | user             | /^user0$/          |
-      | affecteduser     | /^user1$/          |
+      | user             | /^Alice$/          |
+      | affecteduser     | /^Brian$/          |
       | app              | /^files_sharing$/  |
       | subject          | /^shared_with_by$/ |
       | object_name      | /^\/parent.txt$/   |
       | object_type      | /^files$/          |
       | typeicon         | /^icon-shared$/    |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=parent.txt" id=\"\d+\">parent.txt<\/file> with you$/|
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=parent.txt" id=\"\d+\">parent.txt<\/file> with you$/|
 
   @skipOnOcV10.2
   Scenario: different files shared with same user should be listed in activity list of sharee
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and without skeleton files
-    When user "user0" shares file "PARENT/parent.txt" with user "user1" using the sharing API
-    And user "user0" shares file "textfile0.txt" with user "user1" using the sharing API
-    Then the activity number 1 of user "user1" should match these properties:
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    When user "Alice" shares file "PARENT/parent.txt" with user "Brian" using the sharing API
+    And user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
+    Then the activity number 1 of user "Brian" should match these properties:
       | type             | /^shared$/          |
-      | user             | /^user0$/           |
-      | affecteduser     | /^user1$/           |
+      | user             | /^Alice$/           |
+      | affecteduser     | /^Brian$/           |
       | app              | /^files_sharing$/   |
       | subject          | /^shared_with_by$/  |
       | object_name      | /^\/textfile0.txt$/ |
       | object_type      | /^files$/           |
       | typeicon         | /^icon-shared$/     |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <collection><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=parent.txt" id=\"\d+\">parent.txt<\/file><\/collection> with you$/|
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> shared <collection><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file><file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=parent.txt" id=\"\d+\">parent.txt<\/file><\/collection> with you$/|
 
   @skipOnOcV10.2
   Scenario: users checks a group related activity after deleting the group
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user0    |
-      | user1    |
+      | Alice    |
+      | Brian    |
     And group "grp1" has been created
-    And user "user0" has been added to group "grp1"
-    And user "user1" has been added to group "grp1"
-    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
     When the administrator deletes group "grp1" using the provisioning API
-    Then the activity number 1 of user "user1" should match these properties:
+    Then the activity number 1 of user "Brian" should match these properties:
       | type             | /^shared$/          |
-      | user             | /^user0$/           |
-      | affecteduser     | /^user1$/           |
+      | user             | /^Alice$/           |
+      | affecteduser     | /^Brian$/           |
       | app              | /^files_sharing$/   |
       | subject          | /^shared_with_by$/  |
       | object_name      | /^\/textfile0.txt$/ |
       | object_type      | /^files$/           |
       | typeicon         | /^icon-shared$/     |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
 
   @skipOnOcV10.2
   Scenario: users checks a user related activity after deleting the user
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user0    |
-      | user1    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    When the administrator deletes user "user0" using the provisioning API
-    Then the activity number 1 of user "user1" should match these properties:
+      | Alice    |
+      | Brian    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    When the administrator deletes user "Alice" using the provisioning API
+    Then the activity number 1 of user "Brian" should match these properties:
       | type             | /^shared$/          |
-      | user             | /^user0$/           |
-      | affecteduser     | /^user1$/           |
+      | user             | /^Alice$/           |
+      | affecteduser     | /^Brian$/           |
       | app              | /^files_sharing$/   |
       | subject          | /^shared_with_by$/  |
       | object_name      | /^\/textfile0.txt$/ |
       | object_type      | /^files$/           |
       | typeicon         | /^icon-shared$/     |
       | link             | /^%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/$/ |
-      | subject_prepared | /^<user display-name=\"user0\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
+      | subject_prepared | /^<user display-name=\"Alice\">Alice<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=textfile0.txt" id=\"\d+\">textfile0.txt<\/file> with you$/|
 
   @skipOnOcV10.2
   Scenario: Sharer and sharee check activity after sharer deletes shared file
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user0    |
-      | user1    |
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user0" has shared file "/lorem.txt" with user "user1"
-    When user "user0" deletes file "/lorem.txt" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "Alice" has shared file "/lorem.txt" with user "Brian"
+    When user "Alice" deletes file "/lorem.txt" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/lorem.txt$/       |
       | object_type      | /^files$/             |
       | typeicon         | /^icon-delete-color$/ |
       | subject_prepared | /^You deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem\.txt\.d\d+&view=trashbin\" id=\"\d+\">lorem\.txt<\/file>$/ |
-    And the activity number 2 of user "user0" should match these properties:
+    And the activity number 2 of user "Alice" should match these properties:
       | type             | /^shared$/               |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user0$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Alice$/                |
       | app              | /^files_sharing$/        |
       | subject          | /^shared_user_self$/     |
       | object_name      | /^\/lorem.txt$/          |
       | object_type      | /^files$/                |
       | typeicon         | /^icon-shared$/          |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\.d\d+&view=trashbin\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
-    And the activity number 1 of user "user1" should match these properties:
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\.d\d+&view=trashbin\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"Brian Murphy\">Brian<\/user>$/|
+    And the activity number 1 of user "Brian" should match these properties:
       | type             | /^file_deleted$/         |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user1$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Brian$/                |
       | app              | /^files$/                |
       | subject          | /^deleted_by$/           |
       | object_name      | /^\/lorem.txt$/          |
       | object_type      | /^files$/                |
       | typeicon         | /^icon-delete-color$/    |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
-    And the activity number 2 of user "user1" should match these properties:
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
+    And the activity number 2 of user "Brian" should match these properties:
       | type             | /^shared$/            |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user1$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Brian$/             |
       | app              | /^files_sharing$/     |
       | subject          | /^shared_with_by$/    |
       | object_name      | /^\/lorem.txt$/       |
       | object_type      | /^files$/             |
       | typeicon         | /^icon-shared$/       |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|
 
   @skipOnOcV10.2
   Scenario: Sharer and sharee check activity after sharee deletes shared file
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user0    |
-      | user1    |
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user0" has shared file "/lorem.txt" with user "user1"
-    When user "user1" deletes file "/lorem.txt" using the WebDAV API
-    Then the activity number 1 of user "user0" should match these properties:
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "Alice" has shared file "/lorem.txt" with user "Brian"
+    When user "Brian" deletes file "/lorem.txt" using the WebDAV API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^shared$/               |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user0$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Alice$/                |
       | app              | /^files_sharing$/        |
       | subject          | /^shared_user_self$/     |
       | object_name      | /^\/lorem.txt$/          |
       | object_type      | /^files$/                |
       | typeicon         | /^icon-shared$/          |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
-    And the activity number 1 of user "user1" should match these properties:
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"Brian Murphy\">Brian<\/user>$/|
+    And the activity number 1 of user "Brian" should match these properties:
       | type             | /^shared$/             |
-      | user             | /^user1$/              |
-      | affecteduser     | /^user1$/              |
+      | user             | /^Brian$/              |
+      | affecteduser     | /^Brian$/              |
       | app              | /^files_sharing$/      |
       | subject          | /^unshared_from_self$/ |
       | typeicon         | /^icon-shared$/    |
-      | subject_prepared | /^You unshared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id="">lorem.txt<\/file> shared by <user display-name=\"User Zero\">user0<\/user> from self$/|
-    And the activity number 2 of user "user1" should match these properties:
+      | subject_prepared | /^You unshared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id="">lorem.txt<\/file> shared by <user display-name=\"Alice Hansen\">Alice<\/user> from self$/|
+    And the activity number 2 of user "Brian" should match these properties:
       | type             | /^shared$/            |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user1$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Brian$/             |
       | app              | /^files_sharing$/     |
       | subject          | /^shared_with_by$/    |
       | object_name      | /^\/lorem.txt$/       |
       | object_type      | /^files$/             |
       | typeicon         | /^icon-shared$/       |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|
 
   @skipOnOcV10.2
   Scenario: Sharer and sharee check activity after sharer deletes shared file and then again restore it
     Given the administrator has enabled DAV tech_preview
     And these users have been created with default attributes and without skeleton files:
       | username |
-      | user0    |
-      | user1    |
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user0" has shared file "/lorem.txt" with user "user1"
-    When user "user0" deletes file "/lorem.txt" using the WebDAV API
-    And user "user0" restores the file with original path "lorem.txt" using the trashbin API
-    Then the activity number 1 of user "user0" should match these properties:
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "Alice" has shared file "/lorem.txt" with user "Brian"
+    When user "Alice" deletes file "/lorem.txt" using the WebDAV API
+    And user "Alice" restores the file with original path "lorem.txt" using the trashbin API
+    Then the activity number 1 of user "Alice" should match these properties:
       | type             | /^file_restored$/     |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^restored_self$/     |
       | object_name      | /^\/lorem.txt$/       |
       | object_type      | /^files$/             |
       | subject_prepared | /^You restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem\.txt\" id=\"\d+\">lorem\.txt<\/file>$/ |
-    And the activity number 2 of user "user0" should match these properties:
+    And the activity number 2 of user "Alice" should match these properties:
       | type             | /^file_deleted$/      |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user0$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Alice$/             |
       | app              | /^files$/             |
       | subject          | /^deleted_self$/      |
       | object_name      | /^\/lorem.txt$/       |
       | object_type      | /^files$/             |
       | typeicon         | /^icon-delete-color$/ |
       | subject_prepared | /^You deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem\.txt\" id=\"\d+\">lorem\.txt<\/file>$/ |
-    And the activity number 3 of user "user0" should match these properties:
+    And the activity number 3 of user "Alice" should match these properties:
       | type             | /^shared$/               |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user0$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Alice$/                |
       | app              | /^files_sharing$/        |
       | subject          | /^shared_user_self$/     |
       | object_name      | /^\/lorem.txt$/          |
       | object_type      | /^files$/                |
       | typeicon         | /^icon-shared$/          |
-      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"User One\">user1<\/user>$/|
-    And the activity number 1 of user "user1" should match these properties:
+      | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt\" id=\"\d+\">lorem.txt<\/file> with <user display-name=\"Brian Murphy\">Brian<\/user>$/|
+    And the activity number 1 of user "Brian" should match these properties:
       | type             | /^file_restored$/     |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user1$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Brian$/             |
       | app              | /^files$/             |
       | subject          | /^restored_by$/     |
       | object_name      | /^\/lorem.txt$/       |
       | object_type      | /^files$/             |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
-    And the activity number 2 of user "user1" should match these properties:
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> restored <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
+    And the activity number 2 of user "Brian" should match these properties:
       | type             | /^file_deleted$/         |
-      | user             | /^user0$/                |
-      | affecteduser     | /^user1$/                |
+      | user             | /^Alice$/                |
+      | affecteduser     | /^Brian$/                |
       | app              | /^files$/                |
       | subject          | /^deleted_by$/           |
       | object_name      | /^\/lorem.txt$/          |
       | object_type      | /^files$/                |
       | typeicon         | /^icon-delete-color$/    |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
-    And the activity number 3 of user "user1" should match these properties:
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> deleted <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file>$/|
+    And the activity number 3 of user "Brian" should match these properties:
       | type             | /^shared$/            |
-      | user             | /^user0$/             |
-      | affecteduser     | /^user1$/             |
+      | user             | /^Alice$/             |
+      | affecteduser     | /^Brian$/             |
       | app              | /^files_sharing$/     |
       | subject          | /^shared_with_by$/    |
       | object_name      | /^\/lorem.txt$/       |
       | object_type      | /^files$/             |
       | typeicon         | /^icon-shared$/       |
-      | subject_prepared | /^<user display-name=\"User Zero\">user0<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|
+      | subject_prepared | /^<user display-name=\"Alice Hansen\">Alice<\/user> shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem.txt" id=\"\d+\">lorem.txt<\/file> with you$/|

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -360,35 +360,35 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the activity number :index should have a message saying that user :user1 has shared :entry with user :user2
+	 * @Then the activity number :index should have a message saying that user :sharer has shared :entry with user :sharee
 	 *
 	 * @param integer $index (starting from 1, newest to the oldest)
-	 * @param string $user1
+	 * @param string $sharer
 	 * @param string $entry
-	 * @param string $user2
+	 * @param string $sharee
 	 *
 	 * @return void
 	 */
 	public function theActivityNumberShouldHaveAMessageSayingThatUserHasSharedWithUser(
 		$index,
-		$user1,
+		$sharer,
 		$entry,
-		$user2
+		$sharee
 	) {
 		if ($index < 1) {
 			throw new InvalidArgumentException(
 				"activity index starts from 1"
 			);
 		}
-		$avatarTextUser1 = \strtoupper($user1[0]);
-		$avatarTextUser2 = \strtoupper($user2[0]);
+		$avatarTextSharer = \strtoupper($sharer[0]);
+		$avatarTextSharee = \strtoupper($sharee[0]);
 		$message = \sprintf(
 			$this->userSharedWithUserMsgFramework,
-			$avatarTextUser1,
-			$user1,
+			$avatarTextSharer,
+			$sharer,
 			$entry,
-			$avatarTextUser2,
-			$user2
+			$avatarTextSharee,
+			$sharee
 		);
 		$latestActivityMessage = $this->activityPage->getActivityMessageOfIndex($index - 1);
 		PHPUnit\Framework\Assert::assertEquals($message, $latestActivityMessage);

--- a/tests/acceptance/features/webUIActivityComments/comments.feature
+++ b/tests/acceptance/features/webUIActivityComments/comments.feature
@@ -6,11 +6,11 @@ Feature: Comment files/folders activities
 
   Background:
     Given using new DAV path
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
 
   Scenario Outline: Commenting on a file/folder should be listed in the activity page
-    Given user "user0" has commented with content "My first comment" on file "<filepath><filename>"
+    Given user "Alice" has commented with content "My first comment" on file "<filepath><filename>"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You commented on <filename>" in the activity page
     And the comment message for activity number 1 in the activity page should be:
@@ -27,8 +27,8 @@ Feature: Comment files/folders activities
       | 'single'quotes/simple-empty-folder/ | for-git-commit      |
 
   Scenario Outline: Comment, and then deleting comment on a file/folder should be listed in the activity page without any comment
-    Given user "user0" has commented with content "My first comment" on file "<filepath><filename>"
-    And user "user0" has deleted the last created comment
+    Given user "Alice" has commented with content "My first comment" on file "<filepath><filename>"
+    And user "Alice" has deleted the last created comment
     When the user browses to the activity page
     Then the activity number 1 should contain message "You commented on <filename>" in the activity page
     And the activity number 1 should not contain any comment message in the activity page
@@ -42,11 +42,11 @@ Feature: Comment files/folders activities
       | 'single'quotes/simple-empty-folder/ | for-git-commit      |
 
   Scenario Outline: Adding a comment on the shared file/folder should be listed on the activity list
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "Brian" has been created with default attributes and without skeleton files
     And group "group1" has been created
-    And user "user1" has been added to group "group1"
-    And user "user0" has shared file "<filename>" with group "group1"
-    And user "user0" has commented with content "My first comment" on file "<filename>"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has shared file "<filename>" with group "group1"
+    And user "Alice" has commented with content "My first comment" on file "<filename>"
     When the user browses to the activity page
     Then the activity number 1 should have message "You commented on <filename>" in the activity page
     And the comment message for activity number 1 in the activity page should be:
@@ -54,25 +54,25 @@ Feature: Comment files/folders activities
     My first comment
     """
     And the activity number 2 should have message "You shared <filename> with group group1" in the activity page
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User Zero commented on <filename>" in the activity page
+    Then the activity number 1 should contain message "Alice Hansen commented on <filename>" in the activity page
     And the comment message for activity number 1 in the activity page should be:
     """
     My first comment
     """
-    And the activity number 2 should have a message saying that user "User Zero" has shared "<filename>" with you
+    And the activity number 2 should have a message saying that user "Alice Hansen" has shared "<filename>" with you
     Examples:
       | filename      |
       | lorem.txt     |
       | simple-folder |
 
   Scenario Outline: Activity for commenting before sharing file/folder should not be listed on the activity list
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "Brian" has been created with default attributes and without skeleton files
     And group "group1" has been created
-    And user "user1" has been added to group "group1"
-    And user "user0" has commented with content "My first comment" on file "<filename>"
-    And user "user0" has shared file "<filename>" with group "group1"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has commented with content "My first comment" on file "<filename>"
+    And user "Alice" has shared file "<filename>" with group "group1"
     When the user browses to the activity page
     Then the activity number 1 should have message "You shared <filename> with group group1" in the activity page
     And the activity number 2 should have message "You commented on <filename>" in the activity page
@@ -80,9 +80,9 @@ Feature: Comment files/folders activities
     """
     My first comment
     """
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" has shared "<filename>" with you
+    Then the activity number 1 should have a message saying that user "Alice Hansen" has shared "<filename>" with you
     And the activity should not have any message with keyword "comment"
     Examples:
       | filename      |
@@ -90,82 +90,82 @@ Feature: Comment files/folders activities
       | simple-folder |
 
   Scenario Outline: Activity for commenting on a shared file/folder by sharee should be listed for sharer as well
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "Brian" has been created with default attributes and without skeleton files
     And group "group1" has been created
-    And user "user1" has been added to group "group1"
-    And user "user0" has shared file "<filename>" with group "group1"
-    And user "user1" has commented with content "My first comment" on file "<filename>"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has shared file "<filename>" with group "group1"
+    And user "Brian" has commented with content "My first comment" on file "<filename>"
     When the user browses to the activity page
-    Then the activity number 1 should contain message "User One commented on <filename>" in the activity page
+    Then the activity number 1 should contain message "Brian Murphy commented on <filename>" in the activity page
     And the comment message for activity number 1 in the activity page should be:
     """
     My first comment
     """
     And the activity number 2 should have message "You shared <filename> with group group1" in the activity page
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
     Then the activity number 1 should have message "You commented on <filename>" in the activity page
     And the comment message for activity number 1 in the activity page should be:
     """
     My first comment
     """
-    And the activity number 2 should have a message saying that user "User Zero" has shared "<filename>" with you
+    And the activity number 2 should have a message saying that user "Alice Hansen" has shared "<filename>" with you
     Examples:
       | filename      |
       | lorem.txt     |
       | simple-folder |
 
   Scenario: Activity for commenting a reshared folder by sharee should be listed for original sharer as well
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "group1" has been created
-    And user "user1" has been added to group "group1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "group1"
-    And user "user1" has shared folder "simple-empty-folder" with user "user2"
-    And user "user2" has commented with content "My first comment" on file "simple-empty-folder"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with group "group1"
+    And user "Brian" has shared folder "simple-empty-folder" with user "Carol"
+    And user "Carol" has commented with content "My first comment" on file "simple-empty-folder"
     When the user browses to the activity page
-    Then the activity number 1 should contain message "User Two commented on simple-empty-folder" in the activity page
+    Then the activity number 1 should contain message "Carol King commented on simple-empty-folder" in the activity page
     And the comment message for activity number 1 in the activity page should be:
     """
     My first comment
     """
-    And the activity number 2 should have a message saying that user "User One" has shared "simple-empty-folder" with user "User Two"
+    And the activity number 2 should have a message saying that user "Brian Murphy" has shared "simple-empty-folder" with user "Carol King"
     And the activity number 3 should have message "You shared simple-empty-folder with group group1" in the activity page
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User Two commented on simple-empty-folder" in the activity page
+    Then the activity number 1 should contain message "Carol King commented on simple-empty-folder" in the activity page
     And the comment message for activity number 1 in the activity page should be:
     """
     My first comment
     """
-    And the activity number 2 should have a message saying that you have shared folder "simple-empty-folder" with user "User Two"
-    And the activity number 3 should have a message saying that user "User Zero" has shared "simple-empty-folder" with you
-    When the user re-logs in as "user2" using the webUI
+    And the activity number 2 should have a message saying that you have shared folder "simple-empty-folder" with user "Carol King"
+    And the activity number 3 should have a message saying that user "Alice Hansen" has shared "simple-empty-folder" with you
+    When the user re-logs in as "Carol" using the webUI
     And the user browses to the activity page
     Then the activity number 1 should contain message "You commented on simple-empty-folder" in the activity page
     And the comment message for activity number 1 in the activity page should be:
     """
     My first comment
     """
-    And the activity number 2 should have a message saying that user "User One" has shared "simple-empty-folder" with you
-    And the activity should not have any message with keyword "User Zero"
+    And the activity number 2 should have a message saying that user "Brian Murphy" has shared "simple-empty-folder" with you
+    And the activity should not have any message with keyword "Alice Hansen"
 
   Scenario: Activity for commenting on a shared file/folder by sharee should be listed for sharer and sharee as well in the activity tab
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared file "lorem.txt" with user "user1"
-    And user "user1" has commented with content "My first comment" on file "lorem.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "lorem.txt" with user "Brian"
+    And user "Brian" has commented with content "My first comment" on file "lorem.txt"
     When the user browses directly to display the details of file "lorem.txt" in folder "/"
-    Then the activity number 1 should contain message "User One commented" in the activity tab
+    Then the activity number 1 should contain message "Brian Murphy commented" in the activity tab
     And the comment message for activity number 1 in the activity tab should be:
     """
     My first comment
     """
-    And the activity number 2 should have message saying that the file is shared with user "User One" in the activity tab
-    When the user re-logs in as "user1" using the webUI
+    And the activity number 2 should have message saying that the file is shared with user "Brian Murphy" in the activity tab
+    When the user re-logs in as "Brian" using the webUI
     And the user browses directly to display the details of file "lorem.txt" in folder "/"
     Then the activity number 1 should have message "You commented" in the activity tab
     And the comment message for activity number 1 in the activity tab should be:
     """
     My first comment
     """
-    And the activity number 2 should have message saying that the file is shared by user "User Zero" in the activity tab
+    And the activity number 2 should have message saying that the file is shared by user "Alice Hansen" in the activity tab

--- a/tests/acceptance/features/webUIActivityCreateUpdate/createFilesFolder.feature
+++ b/tests/acceptance/features/webUIActivityCreateUpdate/createFilesFolder.feature
@@ -5,12 +5,12 @@ Feature: Created files/folders activities
   So that I know what happened in my cloud storage
 
   Background:
-    Given user "user0" has been created with default attributes and without skeleton files
-    And user "user0" has logged in using the webUI
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has logged in using the webUI
 
   @issue-622
   Scenario Outline: Creating new file should be listed in the activity list
-    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should contain message "You created text.txt" in the activity page
@@ -23,7 +23,7 @@ Feature: Created files/folders activities
 
   @issue-622
   Scenario Outline: Creating new file should not be listed in the activity list on following filter
-    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "text.txt"
@@ -37,7 +37,7 @@ Feature: Created files/folders activities
 
   @issue-622
   Scenario Outline: Creating new folder should be listed in the activity list for following filters
-    Given user "user0" has created folder "Docs"
+    Given user "Alice" has created folder "Docs"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should contain message "You created Docs" in the activity page
@@ -50,7 +50,7 @@ Feature: Created files/folders activities
 
   @issue-622
   Scenario Outline: Creating new folder should not be listed in the activity list for following filters
-    Given user "user0" has created folder "Docs"
+    Given user "Alice" has created folder "Docs"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "Docs"
@@ -64,9 +64,9 @@ Feature: Created files/folders activities
 
   @issue-622
   Scenario Outline: Creating multiple files should be listed in the activity list for following filters
-    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should contain message "You created text2.txt, text1.txt, text.txt" in the activity page
@@ -79,9 +79,9 @@ Feature: Created files/folders activities
 
   @issue-622
   Scenario Outline: Creating multiple files should not be listed in the activity list for following filters
-    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "text"
@@ -94,18 +94,18 @@ Feature: Created files/folders activities
       #| Favorites            |
 
   Scenario: Creating multiple files should be listed in the activity list with contracted list
-    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text3.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text1.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text2.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text3.txt"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You created text3.txt, text2.txt, text1.txt" in the activity page
 
   @issue-622
   Scenario Outline: Creating multiple folders should be listed in the activity list for following filters
-    Given user "user0" has created folder "Doc1"
-    And user "user0" has created folder "Doc2"
-    And user "user0" has created folder "Doc3"
+    Given user "Alice" has created folder "Doc1"
+    And user "Alice" has created folder "Doc2"
+    And user "Alice" has created folder "Doc3"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should contain message "You created Doc3, Doc2, Doc1" in the activity page
@@ -118,9 +118,9 @@ Feature: Created files/folders activities
 
   @issue-622
   Scenario Outline: Creating multiple folders should not be listed in the activity list for following filters
-    Given user "user0" has created folder "Doc1"
-    And user "user0" has created folder "Doc2"
-    And user "user0" has created folder "Doc3"
+    Given user "Alice" has created folder "Doc1"
+    And user "Alice" has created folder "Doc2"
+    And user "Alice" has created folder "Doc3"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "Doc"
@@ -135,7 +135,7 @@ Feature: Created files/folders activities
   Scenario: Uploading new file using async should register in the activity list
     Given the administrator has enabled async operations
     And using new DAV path
-    And user "user0" has uploaded the following chunks asynchronously to "/text.txt" with new chunking
+    And user "Alice" has uploaded the following chunks asynchronously to "/text.txt" with new chunking
       | number | content |
       | 1      | AAAAA   |
       | 2      | BBBBB   |
@@ -144,48 +144,48 @@ Feature: Created files/folders activities
     Then the activity number 1 should contain message "You created text.txt" in the activity page
 
   Scenario: Uploading new files using all mechanisms should be listed in the activity list
-    When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/text.txt" with all mechanisms using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/text.txt" with all mechanisms using the WebDAV API
     And the user browses to the activity page
     Then the activity number 1 should contain message "You created text.txt-newdav-newchunking, text.txt-newdav-regular, text.txt-olddav-oldchunking" in the activity page
 
   Scenario: Creating multiple folders should be listed in the activity list with contracted list
-    Given user "user0" has created folder "Doc1"
-    And user "user0" has created folder "Doc2"
-    And user "user0" has created folder "Doc3"
-    And user "user0" has created folder "Doc4"
+    Given user "Alice" has created folder "Doc1"
+    And user "Alice" has created folder "Doc2"
+    And user "Alice" has created folder "Doc3"
+    And user "Alice" has created folder "Doc4"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You created Doc4, Doc3, Doc2" in the activity page
 
   Scenario: Creating multiple folders and files should be listed in activity list
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
-    And user "user0" has created folder "doc/nested"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
+    And user "Alice" has created folder "doc/nested"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You created nested, text1.txt, doc" in the activity page
 
   Scenario: Creating files inside folder should be listed in the activity list
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You created text1.txt, doc" in the activity page
 
   Scenario: Copying files should be shown in activity log
-    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text1.txt"
-    And user "user0" has copied file "/text1.txt" to "/text2.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/text1.txt"
+    And user "Alice" has copied file "/text1.txt" to "/text2.txt"
     When the user browses to the activity page
     And the activity number 1 should contain message "You created text2.txt, text1.txt" in the activity page
 
   Scenario: Copying folder should be shown in activity log as created
-    Given user "user0" has created folder "doc"
-    And user "user0" has copied file "/doc" to "/doc2"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has copied file "/doc" to "/doc2"
     When the user browses to the activity page
     And the activity number 1 should contain message "You created doc2, doc" in the activity page
 
   @issue-622
   Scenario Outline: Copying files to another folder should be shown in activity list for following filters
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
-    And user "user0" has copied file "/text.txt" to "/doc/text.txt"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "Alice" has copied file "/text.txt" to "/doc/text.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should contain message "You created text.txt, text.txt, doc" in the activity page
@@ -198,9 +198,9 @@ Feature: Created files/folders activities
 
   @issue-622
   Scenario Outline: Copying files to another folder should not be shown in activity list for following filters
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
-    And user "user0" has copied file "/text.txt" to "/doc/text.txt"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "Alice" has copied file "/text.txt" to "/doc/text.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "text.txt"
@@ -213,14 +213,14 @@ Feature: Created files/folders activities
       #| Favorites            |
 
   Scenario: Creating new file should not be listed in the activity list when file creation activity has been disabled
-    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_created" using the webUI
     And the user browses to the activity page
     Then the activity list should be empty
 
   Scenario: Creating new folder should not be listed in the activity list when file creation activity has been disabled
-    Given user "user0" has created folder "Docs"
+    Given user "Alice" has created folder "Docs"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_created" using the webUI
     And the user browses to the activity page
@@ -229,7 +229,7 @@ Feature: Created files/folders activities
   Scenario: Uploading new file using async should not be listed in the activity list when file creation activity has been disabled
     Given the administrator has enabled async operations
     And using new DAV path
-    And user "user0" has uploaded the following chunks asynchronously to "/text.txt" with new chunking
+    And user "Alice" has uploaded the following chunks asynchronously to "/text.txt" with new chunking
       | number | content |
       | 1      | AAAAA   |
       | 2      | BBBBB   |
@@ -241,51 +241,51 @@ Feature: Created files/folders activities
 
   Scenario: Uploading new files using all mechanisms should not be listed in the activity list when file created activity has been disabled
     Given the user has browsed to the personal general settings page
-    When user "user0" uploads file "filesForUpload/textfile.txt" to filenames based on "/text.txt" with all mechanisms using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/text.txt" with all mechanisms using the WebDAV API
     And the user disables activity log stream for "file_created" using the webUI
     And the user browses to the activity page
     Then the activity list should be empty
 
   Scenario: Creating files inside folder should not be listed in the activity list stream when file created activity has been disabled
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/doc/text1.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_created" using the webUI
     And the user browses to the activity page
     Then the activity list should be empty
 
   Scenario: Copying files should not be listed in the activity list stream when file created activity has been disabled
-    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text1.txt"
-    And user "user0" has copied file "/text1.txt" to "/text2.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/text1.txt"
+    And user "Alice" has copied file "/text1.txt" to "/text2.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_created" using the webUI
     And the user browses to the activity page
     Then the activity list should be empty
 
   Scenario: Copying folder should not be listed in the activity list stream when file created activity has been disabled
-    Given user "user0" has created folder "doc"
-    And user "user0" has copied file "/doc" to "/doc2"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has copied file "/doc" to "/doc2"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_created" using the webUI
     And the user browses to the activity page
     Then the activity list should be empty
 
   Scenario: Copying files to another folder should not be listed in the activity list stream when file created activity has been disabled
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
-    And user "user0" has copied file "/text.txt" to "/doc/text.txt"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "Alice" has copied file "/text.txt" to "/doc/text.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_created" using the webUI
     And the user browses to the activity page
     Then the activity list should be empty
 
   Scenario: Creating new file activity should be listed in the activity tab
-    Given user "user0" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/text.txt"
     When the user browses directly to display the details of file "/text.txt" in folder "/"
     Then the activity number 1 should contain message "You created text.txt" in the activity tab
 
   Scenario: Creating folders should be listed in the activity tab
-    Given user "user0" has created folder "/Doc1"
+    Given user "Alice" has created folder "/Doc1"
     When the user browses to the files page
     And the user opens the file action menu of folder "Doc1" on the webui
     And the user clicks the details file action on the webui

--- a/tests/acceptance/features/webUIActivityCreateUpdate/updateFilesFolder.feature
+++ b/tests/acceptance/features/webUIActivityCreateUpdate/updateFilesFolder.feature
@@ -5,22 +5,22 @@ Feature: Updated files/folders activities
   So that I know what happened in my cloud storage
 
   Background:
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
 
   Scenario: Changing file contents should be shown in activity list
-    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You changed text.txt" in the activity page
     And the activity number 2 should contain message "You created text.txt" in the activity page
 
   @issue-622
   Scenario Outline: Changing multiple file contents should be shown in activity list for following filters
-    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should have message "You changed text1.txt and text.txt" in the activity page
@@ -34,10 +34,10 @@ Feature: Updated files/folders activities
 
   @issue-622
   Scenario Outline: Changing multiple file contents should not be shown in activity list for following filters
-    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "text1.txt"
@@ -51,10 +51,10 @@ Feature: Updated files/folders activities
       #| Favorites            |
 
   Scenario: Changing multiple files in different order should be shown in activity list in the way it happens
-    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem.txt" to "/text1.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem-big.txt" to "/text1.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You changed text1.txt" in the activity page
     And the activity number 2 should have message "You created text1.txt" in the activity page
@@ -62,11 +62,11 @@ Feature: Updated files/folders activities
     And the activity number 4 should contain message "You created text.txt" in the activity page
 
   Scenario: Changing contents of file inside folder should be shown in activity list
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text.txt"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/doc/text.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem.txt" to "/doc/text1.txt"
-    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "/doc/text1.txt"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/doc/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/doc/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem.txt" to "/doc/text1.txt"
+    And user "Alice" has uploaded file "filesForUpload/new-lorem-big.txt" to "/doc/text1.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You changed text1.txt" in the activity page
     And the activity number 2 should have message "You created text1.txt" in the activity page
@@ -74,17 +74,17 @@ Feature: Updated files/folders activities
     And the activity number 4 should contain message "You created text.txt, doc" in the activity page
 
   Scenario: Changing file contents should not be listed in the activity list stream when file changed activity has been disabled
-    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/text.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_changed" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "changed"
 
   Scenario: Changing contents of file should be shown in the activity tab
-    Given user "user0" has created folder "doc"
-    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/doc/text.txt"
-    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/doc/text.txt"
+    Given user "Alice" has created folder "doc"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/doc/text.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "/doc/text.txt"
     When the user browses directly to display the details of file "/doc/text.txt" in folder "/"
     Then the activity number 1 should have message "You changed text.txt" in the activity tab
     And the activity number 2 should have message "You created text.txt" in the activity tab

--- a/tests/acceptance/features/webUIActivityDeleteRestore/delete.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/delete.feature
@@ -5,12 +5,12 @@ Feature: Deleted files/folders activities
   So that I know what happened in my cloud storage
 
   Background:
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
 
   @issue-622
   Scenario Outline: file deletion should be listed in the activity list for following filters
-    Given user "user0" has deleted file "lorem.txt"
+    Given user "Alice" has deleted file "lorem.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should have message "You deleted lorem.txt" in the activity page
@@ -23,7 +23,7 @@ Feature: Deleted files/folders activities
 
   @issue-622
   Scenario Outline: file deletion should not be listed in the activity list for following filters
-    Given user "user0" has deleted file "lorem.txt"
+    Given user "Alice" has deleted file "lorem.txt"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "lorem.txt"
@@ -36,65 +36,65 @@ Feature: Deleted files/folders activities
       #| Favorites            |
 
   Scenario: folder deletion should be listed in the activity list
-    Given user "user0" has deleted folder "simple-folder"
+    Given user "Alice" has deleted folder "simple-folder"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted simple-folder" in the activity page
 
   Scenario: file inside folder deleted should be listed in the activity list
-    Given user "user0" has deleted file "simple-folder/block-aligned.txt"
+    Given user "Alice" has deleted file "simple-folder/block-aligned.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted block-aligned.txt" in the activity page
 
   Scenario: folder inside folder deleted should be listed in the activity list
-    Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
+    Given user "Alice" has deleted folder "simple-folder/simple-empty-folder"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted simple-empty-folder" in the activity page
 
   Scenario: Deleting multiple folders should be listed in the activity list
-    Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
-    And user "user0" has deleted folder "0"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted folder "strängé नेपाली folder"
+    Given user "Alice" has deleted folder "simple-folder/simple-empty-folder"
+    And user "Alice" has deleted folder "0"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted folder "strängé नेपाली folder"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted strängé नेपाली folder, 'single'quotes, simple-empty-folder, 0 and simple-empty-folder" in the activity page
 
   Scenario: Deleting 6 or more folders at once should be contracted in the activity list
-    Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
-    And user "user0" has deleted folder "0"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted folder "strängé नेपाली folder"
-    And user "user0" has deleted folder "strängé नेपाली folder empty"
+    Given user "Alice" has deleted folder "simple-folder/simple-empty-folder"
+    And user "Alice" has deleted folder "0"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted folder "strängé नेपाली folder"
+    And user "Alice" has deleted folder "strängé नेपाली folder empty"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted strängé नेपाली folder empty, strängé नेपाली folder, 'single'quotes and 3 more" in the activity page
 
   Scenario: Deleting multiple files should be listed in the activity list
-    Given user "user0" has deleted file "simple-folder/lorem.txt"
-    And user "user0" has deleted file "lorem.txt"
-    And user "user0" has deleted file "data.zip"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
+    Given user "Alice" has deleted file "simple-folder/lorem.txt"
+    And user "Alice" has deleted file "lorem.txt"
+    And user "Alice" has deleted file "data.zip"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted testavatar.png, textfile0.txt, data.zip, lorem.txt and lorem.txt" in the activity page
 
   Scenario: Deleting 6 or more files at once should be contracted in the activity list
-    Given user "user0" has deleted file "simple-folder/lorem.txt"
-    And user "user0" has deleted file "lorem.txt"
-    And user "user0" has deleted file "data.zip"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted file "'single'quotes/for-git-commit"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
+    Given user "Alice" has deleted file "simple-folder/lorem.txt"
+    And user "Alice" has deleted file "lorem.txt"
+    And user "Alice" has deleted file "data.zip"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted file "'single'quotes/for-git-commit"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted testavatar.png, for-git-commit, textfile0.txt and 3 more" in the activity page
 
   @issue-622
   Scenario Outline: Deleting mix of files and folders at once should be listed in the activity list for the following filters
-    Given user "user0" has deleted folder "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
@@ -107,11 +107,11 @@ Feature: Deleted files/folders activities
 
   @issue-622
   Scenario Outline: Deleting mix of files and folders at once should not be listed in the activity list for the following filters
-    Given user "user0" has deleted folder "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "deleted"
@@ -124,24 +124,24 @@ Feature: Deleted files/folders activities
       #| Favorites            |
 
   Scenario: Deleting mix of files and folders 6 or more at once should be contracted in the activity list
-    Given user "user0" has deleted folder "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has deleted file "data.zip"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has deleted file "data.zip"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted data.zip, simple-empty-folder, textfile0.txt and 3 more" in the activity page
 
   Scenario: folder deletion should not be listed in the activity list stream when file deleted activity has been disabled
-    Given user "user0" has deleted folder "simple-folder"
+    Given user "Alice" has deleted folder "simple-folder"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_deleted" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "deleted"
 
   Scenario: file inside folder deleted should not be listed in the activity list stream when file deleted activity has been disabled
-    Given user "user0" has deleted file "simple-folder/block-aligned.txt"
+    Given user "Alice" has deleted file "simple-folder/block-aligned.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_deleted" using the webUI
     And the user browses to the activity page
@@ -150,30 +150,29 @@ Feature: Deleted files/folders activities
   Scenario: Sharer and sharee check activity after sharer deletes shared file
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
+      | Brian    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And the user has reloaded the current page of the webUI
     When the user deletes file "textfile0.txt" using the webUI
     And the user browses to the activity page
     Then the activity number 1 should contain message "You deleted textfile0.txt" in the activity page
-    And the activity number 2 should have a message saying that you have shared file "textfile0.txt" with user "User One"
-    When the user re-logs in as "user1" using the webUI
+    And the activity number 2 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy"
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User Zero deleted textfile0.txt" in the activity page
-    And the activity number 2 should have a message saying that user "User Zero" has shared "textfile0.txt" with you
+    Then the activity number 1 should contain message "Alice Hansen deleted textfile0.txt" in the activity page
+    And the activity number 2 should have a message saying that user "Alice Hansen" has shared "textfile0.txt" with you
 
   @skipOnOcV10.2
   Scenario: Sharer and sharee check activity after sharee deletes shared file
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And the user re-logs in as "user1" using the webUI
+      | Brian    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And the user re-logs in as "Brian" using the webUI
     When the user deletes file "textfile0.txt" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "User Zero" from self
-    And the activity number 2 should contain message "User Zero shared textfile0.txt with you" in the activity page
-    When the user re-logs in as "user0" using the webUI
+    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "Alice Hansen" from self
+    And the activity number 2 should contain message "Alice Hansen shared textfile0.txt with you" in the activity page
+    When the user re-logs in as "Alice" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User One"
-
+    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy"

--- a/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/restore.feature
@@ -6,13 +6,13 @@ Feature: Restored files/folders activities
 
   Background:
     Given the administrator has enabled DAV tech_preview
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
 
   @issue-622
   Scenario Outline: Restoring deleted folder should be listed in the activity list for the following filters
-    Given user "user0" has deleted folder "simple-folder"
-    And user "user0" has restored the folder with original path "simple-folder"
+    Given user "Alice" has deleted folder "simple-folder"
+    And user "Alice" has restored the folder with original path "simple-folder"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should have message "You restored simple-folder" in the activity page
@@ -26,8 +26,8 @@ Feature: Restored files/folders activities
 
   @issue-622
   Scenario Outline: Restoring deleted folder should not be listed in the activity list for the following filters
-    Given user "user0" has deleted folder "simple-folder"
-    And user "user0" has restored the folder with original path "simple-folder"
+    Given user "Alice" has deleted folder "simple-folder"
+    And user "Alice" has restored the folder with original path "simple-folder"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity should not have any message with keyword "restored"
@@ -41,149 +41,149 @@ Feature: Restored files/folders activities
       #| Favorites            |
 
   Scenario: Restoring folder that was inside a folder should be listed in the activity list
-    Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
-    And user "user0" has restored the folder with original path "simple-folder/simple-empty-folder"
+    Given user "Alice" has deleted folder "simple-folder/simple-empty-folder"
+    And user "Alice" has restored the folder with original path "simple-folder/simple-empty-folder"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-empty-folder" in the activity page
     And the activity number 2 should have message "You deleted simple-empty-folder" in the activity page
 
   Scenario: Restoring deleted file should be listed in the activity list
-    Given user "user0" has deleted folder "lorem.txt"
-    And user "user0" has restored the folder with original path "lorem.txt"
+    Given user "Alice" has deleted folder "lorem.txt"
+    And user "Alice" has restored the folder with original path "lorem.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt" in the activity page
     And the activity number 2 should have message "You deleted lorem.txt" in the activity page
 
   Scenario: Restoring deleted file that was inside a folder should be listed in the activity list
-    Given user "user0" has deleted folder "simple-folder/lorem.txt"
-    And user "user0" has restored the folder with original path "simple-folder/lorem.txt"
+    Given user "Alice" has deleted folder "simple-folder/lorem.txt"
+    And user "Alice" has restored the folder with original path "simple-folder/lorem.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt" in the activity page
     And the activity number 2 should have message "You deleted lorem.txt" in the activity page
 
   Scenario: Restoring multiple deleted folders should be listed in the activity list
-    Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
-    And user "user0" has deleted folder "0"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted folder "strängé नेपाली folder"
-    And user "user0" has restored the folder with original path "strängé नेपाली folder"
-    And user "user0" has restored the folder with original path "'single'quotes"
-    And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
-    And user "user0" has restored the folder with original path "0"
-    And user "user0" has restored the folder with original path "simple-folder/simple-empty-folder"
+    Given user "Alice" has deleted folder "simple-folder/simple-empty-folder"
+    And user "Alice" has deleted folder "0"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted folder "strängé नेपाली folder"
+    And user "Alice" has restored the folder with original path "strängé नेपाली folder"
+    And user "Alice" has restored the folder with original path "'single'quotes"
+    And user "Alice" has restored the folder with original path "folder with space/simple-empty-folder"
+    And user "Alice" has restored the folder with original path "0"
+    And user "Alice" has restored the folder with original path "simple-folder/simple-empty-folder"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-empty-folder, 0, simple-empty-folder, 'single'quotes and strängé नेपाली folder" in the activity page
     And the activity number 2 should have message "You deleted strängé नेपाली folder, 'single'quotes, simple-empty-folder, 0 and simple-empty-folder" in the activity page
 
   Scenario: Restoring multiple deleted folders 6 or more should be contracted in the activity list
-    Given user "user0" has deleted folder "simple-folder/simple-empty-folder"
-    And user "user0" has deleted folder "0"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted folder "strängé नेपाली folder"
-    And user "user0" has deleted folder "strängé नेपाली folder empty"
-    And user "user0" has restored the folder with original path "strängé नेपाली folder empty"
-    And user "user0" has restored the folder with original path "strängé नेपाली folder"
-    And user "user0" has restored the folder with original path "'single'quotes"
-    And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
-    And user "user0" has restored the folder with original path "0"
-    And user "user0" has restored the folder with original path "simple-folder/simple-empty-folder"
+    Given user "Alice" has deleted folder "simple-folder/simple-empty-folder"
+    And user "Alice" has deleted folder "0"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted folder "strängé नेपाली folder"
+    And user "Alice" has deleted folder "strängé नेपाली folder empty"
+    And user "Alice" has restored the folder with original path "strängé नेपाली folder empty"
+    And user "Alice" has restored the folder with original path "strängé नेपाली folder"
+    And user "Alice" has restored the folder with original path "'single'quotes"
+    And user "Alice" has restored the folder with original path "folder with space/simple-empty-folder"
+    And user "Alice" has restored the folder with original path "0"
+    And user "Alice" has restored the folder with original path "simple-folder/simple-empty-folder"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored simple-empty-folder, 0, simple-empty-folder and 3 more" in the activity page
     And the activity number 2 should have message "You deleted strängé नेपाली folder empty, strängé नेपाली folder, 'single'quotes and 3 more" in the activity page
 
   Scenario: Restoring multiple deleted files should be listed in the activity list
-    Given user "user0" has deleted file "simple-folder/lorem.txt"
-    And user "user0" has deleted file "lorem.txt"
-    And user "user0" has deleted file "data.zip"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the file with original path "textfile0.txt"
-    And user "user0" has restored the file with original path "data.zip"
-    And user "user0" has restored the file with original path "lorem.txt"
-    And user "user0" has restored the file with original path "simple-folder/lorem.txt"
+    Given user "Alice" has deleted file "simple-folder/lorem.txt"
+    And user "Alice" has deleted file "lorem.txt"
+    And user "Alice" has deleted file "data.zip"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the file with original path "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the file with original path "textfile0.txt"
+    And user "Alice" has restored the file with original path "data.zip"
+    And user "Alice" has restored the file with original path "lorem.txt"
+    And user "Alice" has restored the file with original path "simple-folder/lorem.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt, lorem.txt, data.zip, textfile0.txt and testavatar.png" in the activity page
     And the activity number 2 should have message "You deleted testavatar.png, textfile0.txt, data.zip, lorem.txt and lorem.txt" in the activity page
 
   Scenario: Restoring multiple deleted folders 6 or more should be contracted in the activity list
-    Given user "user0" has deleted file "simple-folder/lorem.txt"
-    And user "user0" has deleted file "lorem.txt"
-    And user "user0" has deleted file "data.zip"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted file "'single'quotes/for-git-commit"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the file with original path "'single'quotes/for-git-commit"
-    And user "user0" has restored the file with original path "textfile0.txt"
-    And user "user0" has restored the file with original path "data.zip"
-    And user "user0" has restored the file with original path "lorem.txt"
-    And user "user0" has restored the file with original path "simple-folder/lorem.txt"
+    Given user "Alice" has deleted file "simple-folder/lorem.txt"
+    And user "Alice" has deleted file "lorem.txt"
+    And user "Alice" has deleted file "data.zip"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted file "'single'quotes/for-git-commit"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the file with original path "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the file with original path "'single'quotes/for-git-commit"
+    And user "Alice" has restored the file with original path "textfile0.txt"
+    And user "Alice" has restored the file with original path "data.zip"
+    And user "Alice" has restored the file with original path "lorem.txt"
+    And user "Alice" has restored the file with original path "simple-folder/lorem.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored lorem.txt, lorem.txt, data.zip and 3 more" in the activity page
     And the activity number 2 should have message "You deleted testavatar.png, for-git-commit, textfile0.txt and 3 more" in the activity page
 
   Scenario: Restoring multiple files/folders should be listed in the activity page
-    Given user "user0" has deleted folder "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
-    And user "user0" has restored the file with original path "textfile0.txt"
-    And user "user0" has restored the folder with original path "'single'quotes"
-    And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the folder with original path "0"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has restored the folder with original path "folder with space/simple-empty-folder"
+    And user "Alice" has restored the file with original path "textfile0.txt"
+    And user "Alice" has restored the folder with original path "'single'quotes"
+    And user "Alice" has restored the file with original path "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the folder with original path "0"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored 0, testavatar.png, 'single'quotes, textfile0.txt and simple-empty-folder" in the activity page
     And the activity number 2 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
 
   Scenario: Restoring multiple files/folders 6 or more should be contracted in the activity page
-    Given user "user0" has deleted folder "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has deleted file "data.zip"
-    And user "user0" has restored the folder with original path "data.zip"
-    And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
-    And user "user0" has restored the file with original path "textfile0.txt"
-    And user "user0" has restored the folder with original path "'single'quotes"
-    And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the folder with original path "0"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has deleted file "data.zip"
+    And user "Alice" has restored the folder with original path "data.zip"
+    And user "Alice" has restored the folder with original path "folder with space/simple-empty-folder"
+    And user "Alice" has restored the file with original path "textfile0.txt"
+    And user "Alice" has restored the folder with original path "'single'quotes"
+    And user "Alice" has restored the file with original path "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the folder with original path "0"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored 0, testavatar.png, 'single'quotes and 3 more" in the activity page
     And the activity number 2 should have message "You deleted data.zip, simple-empty-folder, textfile0.txt and 3 more" in the activity page
 
   Scenario: Restoring files/folders in different order than the previous one should be listed in the order of actions
-    Given user "user0" has deleted folder "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
-    And user "user0" has restored the folder with original path "'single'quotes"
-    And user "user0" has restored the folder with original path "0"
-    And user "user0" has restored the file with original path "textfile0.txt"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has restored the file with original path "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the folder with original path "folder with space/simple-empty-folder"
+    And user "Alice" has restored the folder with original path "'single'quotes"
+    And user "Alice" has restored the folder with original path "0"
+    And user "Alice" has restored the file with original path "textfile0.txt"
     When the user browses to the activity page
     Then the activity number 1 should have message "You restored textfile0.txt, 0, 'single'quotes, simple-empty-folder and testavatar.png" in the activity page
     And the activity number 2 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
 
   @issue-622
   Scenario Outline: Deleting and restoring each files/folders respectively should be listed in the same order for following filters
-    Given user "user0" has deleted folder "0"
-    And user "user0" has restored the folder with original path "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has restored the folder with original path "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has restored the file with original path "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has restored the folder with original path "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the file with original path "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has restored the folder with original path "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has restored the file with original path "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has restored the folder with original path "folder with space/simple-empty-folder"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
     Then the activity number 1 should have message "You restored simple-empty-folder" in the activity page
@@ -204,29 +204,29 @@ Feature: Restored files/folders activities
       | Favorites         |
 
   Scenario: Deleting-Restoring-Deleting files/folders should be listed in the order
-    Given user "user0" has deleted folder "0"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
-    And user "user0" has restored the file with original path "strängé नेपाली folder/testavatar.png"
-    And user "user0" has restored the folder with original path "folder with space/simple-empty-folder"
-    And user "user0" has restored the folder with original path "'single'quotes"
-    And user "user0" has restored the folder with original path "0"
-    And user "user0" has restored the file with original path "textfile0.txt"
-    And user "user0" has deleted folder "0"
-    And user "user0" has deleted folder "'single'quotes"
-    And user "user0" has deleted file "strängé नेपाली folder/testavatar.png"
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has deleted folder "folder with space/simple-empty-folder"
+    Given user "Alice" has deleted folder "0"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
+    And user "Alice" has restored the file with original path "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has restored the folder with original path "folder with space/simple-empty-folder"
+    And user "Alice" has restored the folder with original path "'single'quotes"
+    And user "Alice" has restored the folder with original path "0"
+    And user "Alice" has restored the file with original path "textfile0.txt"
+    And user "Alice" has deleted folder "0"
+    And user "Alice" has deleted folder "'single'quotes"
+    And user "Alice" has deleted file "strängé नेपाली folder/testavatar.png"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has deleted folder "folder with space/simple-empty-folder"
     When the user browses to the activity page
     Then the activity number 1 should have message "You deleted simple-empty-folder, textfile0.txt, testavatar.png, 'single'quotes and 0" in the activity page
     And the activity number 2 should have message "You restored textfile0.txt, 0, 'single'quotes, simple-empty-folder and testavatar.png" in the activity page
     And the activity number 3 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
 
   Scenario: Restoring deleted folder should not be listed in the activity list stream when file restored activity has been disabled
-    Given user "user0" has deleted folder "simple-folder"
-    And user "user0" has restored the folder with original path "simple-folder"
+    Given user "Alice" has deleted folder "simple-folder"
+    And user "Alice" has restored the folder with original path "simple-folder"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_restored" using the webUI
     And the user browses to the activity page
@@ -234,8 +234,8 @@ Feature: Restored files/folders activities
     And the activity should not have any message with keyword "restored"
 
   Scenario: Restoring deleted file should not be listed in the activity list stream when file restored activity has been disabled
-    Given user "user0" has deleted file "lorem.txt"
-    And user "user0" has restored the file with original path "lorem.txt"
+    Given user "Alice" has deleted file "lorem.txt"
+    And user "Alice" has restored the file with original path "lorem.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "file_restored" using the webUI
     And the user browses to the activity page
@@ -243,8 +243,8 @@ Feature: Restored files/folders activities
     And the activity should not have any message with keyword "restored"
 
   Scenario: Restoring deleted file should be listed in the activity tab
-    Given user "user0" has deleted folder "lorem.txt"
-    And user "user0" has restored the folder with original path "lorem.txt"
+    Given user "Alice" has deleted folder "lorem.txt"
+    And user "Alice" has restored the folder with original path "lorem.txt"
     When the user browses directly to display the details of file "lorem.txt" in folder "/"
     Then the activity number 1 should have message "You restored lorem.txt" in the activity tab
     And the activity number 2 should have message "You deleted lorem.txt" in the activity tab
@@ -252,35 +252,35 @@ Feature: Restored files/folders activities
   Scenario: Sharer and sharee check activity after sharer deletes a shared file and then restores it
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
+      | Brian    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And the user has reloaded the current page of the webUI
-    And user "user0" has deleted file "textfile0.txt"
-    And user "user0" has restored the file with original path "textfile0.txt"
+    And user "Alice" has deleted file "textfile0.txt"
+    And user "Alice" has restored the file with original path "textfile0.txt"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You restored textfile0.txt" in the activity page
     And the activity number 2 should contain message "You deleted textfile0.txt" in the activity page
-    And the activity number 3 should have a message saying that you have shared file "textfile0.txt" with user "User One"
-    When the user re-logs in as "user1" using the webUI
+    And the activity number 3 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy"
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User Zero restored textfile0.txt" in the activity page
-    And the activity number 2 should contain message "User Zero deleted textfile0.txt" in the activity page
-    And the activity number 3 should have a message saying that user "User Zero" has shared "textfile0.txt" with you
+    Then the activity number 1 should contain message "Alice Hansen restored textfile0.txt" in the activity page
+    And the activity number 2 should contain message "Alice Hansen deleted textfile0.txt" in the activity page
+    And the activity number 3 should have a message saying that user "Alice Hansen" has shared "textfile0.txt" with you
 
   Scenario: Sharer and sharee check activity after sharee deletes a shared file and then restores it
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And the user re-logs in as "user1" using the webUI
-    And user "user1" has deleted file "simple-folder/lorem.txt"
-    And user "user1" has restored the file with original path "simple-folder/lorem.txt"
+      | Brian    |
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And the user re-logs in as "Brian" using the webUI
+    And user "Brian" has deleted file "simple-folder/lorem.txt"
+    And user "Brian" has restored the file with original path "simple-folder/lorem.txt"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You restored lorem.txt" in the activity page
     And the activity number 2 should contain message "You deleted lorem.txt" in the activity page
-    And the activity number 3 should contain message "User Zero shared simple-folder with you" in the activity page
-    When the user re-logs in as "user0" using the webUI
+    And the activity number 3 should contain message "Alice Hansen shared simple-folder with you" in the activity page
+    When the user re-logs in as "Alice" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User One restored lorem.txt" in the activity page
-    And the activity number 2 should contain message "User One deleted lorem.txt" in the activity page
-    And the activity number 3 should have a message saying that you have shared folder "simple-folder" with user "User One"
+    Then the activity number 1 should contain message "Brian Murphy restored lorem.txt" in the activity page
+    And the activity number 2 should contain message "Brian Murphy deleted lorem.txt" in the activity page
+    And the activity number 3 should have a message saying that you have shared folder "simple-folder" with user "Brian Murphy"

--- a/tests/acceptance/features/webUIActivityDeleteRestore/restoreUsingWebUI.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/restoreUsingWebUI.feature
@@ -5,11 +5,11 @@ Feature: Restored files/folders activities
   So that I know what happened in my cloud storage
 
   Background:
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
 
   Scenario Outline: Restore a file using the webUI and check the activity
-    Given user "user0" has deleted file "<file>"
+    Given user "Alice" has deleted file "<file>"
     And the user has browsed to the trashbin page
     When the user restores file "lorem.txt" from the trashbin using the webUI
     And the user browses to the activity page
@@ -20,7 +20,7 @@ Feature: Restored files/folders activities
       | simple-folder/lorem.txt |
 
   Scenario Outline: Restore a folder using the webUI and check the activity
-    Given user "user0" has deleted folder "<deleted-folder>"
+    Given user "Alice" has deleted folder "<deleted-folder>"
     And the user has browsed to the trashbin page
     When the user restores folder "<restored-folder>" from the trashbin using the webUI
     And the user browses to the activity page

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
@@ -5,17 +5,17 @@ Feature: public link sharing file/folders activities
   So that I know what happened in my cloud storage
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has logged in using the webUI
 
   Scenario: Creating a public link of a folder and file should be listed in the activity list
-    Given user "user1" has created a public link share of folder "simple-folder"
-    And user "user1" has created a public link share of file "textfile0.txt"
+    Given user "Brian" has created a public link share of folder "simple-folder"
+    And user "Brian" has created a public link share of file "textfile0.txt"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You shared textfile0.txt and simple-folder via link" in the activity page
 
   Scenario: Uploading a file to a public shared folder should be listed in the activity list
-    Given user "user1" has created a public link share with settings
+    Given user "Brian" has created a public link share with settings
       | path        | simple-folder |
       | permissions | create        |
     And the public has uploaded file "test.txt" with content "This is a test"
@@ -24,7 +24,7 @@ Feature: public link sharing file/folders activities
 
   @issue-690
   Scenario: Downloading a file from a public shared folder using API should be listed in the activity list
-    Given user "user1" has created a public link share of folder "simple-folder"
+    Given user "Brian" has created a public link share of folder "simple-folder"
     When the public downloads file "lorem.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API
     And the user browses to the activity page
     Then the activity number 1 should contain message "You shared simple-folder via link" in the activity page
@@ -45,15 +45,15 @@ Feature: public link sharing file/folders activities
     Then the activity number 1 should contain message "Public shared folder simple-folder was downloaded" in the activity page
 
   Scenario: Creating a public link of a folder and file should not be listed in the activity list stream when shared activity has been disabled
-    Given user "user1" has created a public link share of folder "simple-folder"
-    And user "user1" has created a public link share of file "textfile0.txt"
+    Given user "Brian" has created a public link share of folder "simple-folder"
+    And user "Brian" has created a public link share of file "textfile0.txt"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "shared" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "shared"
 
   Scenario: Uploading a file to a public shared folder should not be listed in the activity list stream when file created activity has been disabled
-    Given user "user1" has created a public link share with settings
+    Given user "Brian" has created a public link share with settings
       | path        | simple-folder |
       | permissions | create        |
     And the public has uploaded file "test.txt" with content "This is a test"

--- a/tests/acceptance/features/webUIActivitySharingExternal/sharingFederation.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/sharingFederation.feature
@@ -6,60 +6,60 @@ Feature: federation sharing file/folder activities
 
   Background:
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and skeleton files
     And using server "LOCAL"
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has logged in using the webUI
 
   Scenario: Sharing a folder with a remote server should not be listed in the activity list of a sharer if the sharee has not accepted the share
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user2" from server "REMOTE"
+    Given user "Brian" from server "LOCAL" has shared "simple-folder" with user "Carol" from server "REMOTE"
     When the user browses to the activity page
     Then the activity should not have any message with keyword "remote share"
 
   Scenario: Sharing a folder with a remote server should be listed in the activity list of a sharer
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user2" from server "REMOTE"
-    When user "user2" from server "REMOTE" accepts the last pending share using the sharing API
+    Given user "Brian" from server "LOCAL" has shared "simple-folder" with user "Carol" from server "REMOTE"
+    When user "Carol" from server "REMOTE" accepts the last pending share using the sharing API
     And the user browses to the activity page
-    Then the activity number 1 should contain message "user2@… accepted remote share simple-folder" in the activity page
+    Then the activity number 1 should contain message "Carol@… accepted remote share simple-folder" in the activity page
 
   Scenario: Sharing a file with a remote server should be listed in the activity list of a sharer
-    Given user "user1" from server "LOCAL" has shared "textfile0.txt" with user "user2" from server "REMOTE"
-    When user "user2" from server "REMOTE" accepts the last pending share using the sharing API
+    Given user "Brian" from server "LOCAL" has shared "textfile0.txt" with user "Carol" from server "REMOTE"
+    When user "Carol" from server "REMOTE" accepts the last pending share using the sharing API
     And the user browses to the activity page
-    Then the activity number 1 should contain message "user2@… accepted remote share textfile0.txt" in the activity page
+    Then the activity number 1 should contain message "Carol@… accepted remote share textfile0.txt" in the activity page
 
   Scenario: Sharing a file/folder with a remote server should be listed in the activity list of a sharee eventhough they have not accepted the share
-    Given user "user2" from server "REMOTE" has shared "textfile0.txt" with user "user1" from server "LOCAL"
-    And user "user2" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    Given user "Carol" from server "REMOTE" has shared "textfile0.txt" with user "Brian" from server "LOCAL"
+    And user "Carol" from server "REMOTE" has shared "simple-folder" with user "Brian" from server "LOCAL"
     When the user browses to the activity page
-    Then the activity number 1 should contain message "You received a new remote share simple-folder from user2@…" in the activity page
-    And the activity number 2 should contain message "You received a new remote share textfile0.txt from user2@…" in the activity page
+    Then the activity number 1 should contain message "You received a new remote share simple-folder from Carol@…" in the activity page
+    And the activity number 2 should contain message "You received a new remote share textfile0.txt from Carol@…" in the activity page
 
   Scenario: remote sharee does not get new activity message after accepting the pending share
-    Given user "user2" from server "REMOTE" has shared "textfile0.txt" with user "user1" from server "LOCAL"
-    When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
+    Given user "Carol" from server "REMOTE" has shared "textfile0.txt" with user "Brian" from server "LOCAL"
+    When user "Brian" from server "LOCAL" accepts the last pending share using the sharing API
     And the user browses to the activity page
-    Then the activity number 1 should contain message "You received a new remote share textfile0.txt from user2@…" in the activity page
+    Then the activity number 1 should contain message "You received a new remote share textfile0.txt from Carol@…" in the activity page
 
   Scenario: Sharing a folder with a remote server should not be listed in the activity list stream when remote share activity has been disabled
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user2" from server "REMOTE"
+    Given user "Brian" from server "LOCAL" has shared "simple-folder" with user "Carol" from server "REMOTE"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "remote_share" using the webUI
-    And user "user2" from server "REMOTE" accepts the last pending share using the sharing API
+    And user "Carol" from server "REMOTE" accepts the last pending share using the sharing API
     And the user browses to the activity page
     Then the activity should not have any message with keyword "remote share"
 
   Scenario: Sharing a file with a remote server should not be listed in the activity list stream when remote share activity has been disabled
-    Given user "user1" from server "LOCAL" has shared "textfile0.txt" with user "user2" from server "REMOTE"
+    Given user "Brian" from server "LOCAL" has shared "textfile0.txt" with user "Carol" from server "REMOTE"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "remote_share" using the webUI
-    And user "user2" from server "REMOTE" accepts the last pending share using the sharing API
+    And user "Carol" from server "REMOTE" accepts the last pending share using the sharing API
     And the user browses to the activity page
     Then the activity should not have any message with keyword "remote share"
 
   Scenario: Receiving a file/folder from a remote server should not be listed in the activity list stream when remote share activity has been disabled
-    Given user "user2" from server "REMOTE" has shared "textfile0.txt" with user "user1" from server "LOCAL"
-    And user "user2" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    Given user "Carol" from server "REMOTE" has shared "textfile0.txt" with user "Brian" from server "LOCAL"
+    And user "Carol" from server "REMOTE" has shared "simple-folder" with user "Brian" from server "LOCAL"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "remote_share" using the webUI
     And the user browses to the activity page

--- a/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
+++ b/tests/acceptance/features/webUIActivitySharingInternal/sharingInternal.feature
@@ -5,42 +5,42 @@ Feature: Sharing file/folders activities
   So that I know what happened in my cloud storage
 
   Background:
-    Given user "user0" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and skeleton files
 
   Scenario: Sharing a file/folder with a user should be listed in the activity list of a sharer
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
-      | user1    |
-      | user2    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user0" has shared folder "folder with space" with user "user2"
-    And user "user0" has shared file "simple-folder/lorem.txt" with user "user1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with user "user2"
-    And user "user0" has logged in using the webUI
+      | Brian    |
+      | Carol    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared folder "folder with space" with user "Carol"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with user "Brian"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with user "Carol"
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have shared folder "simple-empty-folder" with user "User Two"
-    And the activity number 2 should have a message saying that you have shared file "lorem.txt" with user "User One"
-    And the activity number 3 should have a message saying that you have shared folder "folder with space" with user "User Two"
-    And the activity number 4 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+    Then the activity number 1 should have a message saying that you have shared folder "simple-empty-folder" with user "Carol King"
+    And the activity number 2 should have a message saying that you have shared file "lorem.txt" with user "Brian Murphy"
+    And the activity number 3 should have a message saying that you have shared folder "folder with space" with user "Carol King"
+    And the activity number 4 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy"
     When the user filters activity list by "Activities by you"
-    Then the activity number 1 should have a message saying that you have shared folder "simple-empty-folder" with user "User Two"
-    And the activity number 2 should have a message saying that you have shared file "lorem.txt" with user "User One"
-    And the activity number 3 should have a message saying that you have shared folder "folder with space" with user "User Two"
-    And the activity number 4 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+    Then the activity number 1 should have a message saying that you have shared folder "simple-empty-folder" with user "Carol King"
+    And the activity number 2 should have a message saying that you have shared file "lorem.txt" with user "Brian Murphy"
+    And the activity number 3 should have a message saying that you have shared folder "folder with space" with user "Carol King"
+    And the activity number 4 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy"
     When the user filters activity list by "Shares"
-    Then the activity number 1 should have a message saying that you have shared folder "simple-empty-folder" with user "User Two"
-    And the activity number 2 should have a message saying that you have shared file "lorem.txt" with user "User One"
-    And the activity number 3 should have a message saying that you have shared folder "folder with space" with user "User Two"
-    And the activity number 4 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+    Then the activity number 1 should have a message saying that you have shared folder "simple-empty-folder" with user "Carol King"
+    And the activity number 2 should have a message saying that you have shared file "lorem.txt" with user "Brian Murphy"
+    And the activity number 3 should have a message saying that you have shared folder "folder with space" with user "Carol King"
+    And the activity number 4 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy"
 
   Scenario: Sharing a file/folder with a group should be listed in the activity list of a sharer
     Given group "grp1" has been created
     And group "grp2" has been created
-    And user "user0" has shared file "textfile0.txt" with group "grp1"
-    And user "user0" has shared folder "folder with space" with group "grp2"
-    And user "user0" has shared file "simple-folder/lorem.txt" with group "grp1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "grp2"
-    And user "user0" has logged in using the webUI
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Alice" has shared folder "folder with space" with group "grp2"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with group "grp1"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with group "grp2"
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
     Then the activity number 1 should contain message "You shared simple-empty-folder with group grp2" in the activity page
     And the activity number 2 should contain message "You shared lorem.txt with group grp1" in the activity page
@@ -58,45 +58,45 @@ Feature: Sharing file/folders activities
     And the activity number 4 should contain message "You shared textfile0.txt with group grp1" in the activity page
 
   Scenario: Sharing a file/folder with a user should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user0" has shared folder "folder with space" with user "user1"
-    And user "user0" has shared file "simple-folder/lorem.txt" with user "user1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with user "user1"
-    And user "user1" has logged in using the webUI
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared folder "folder with space" with user "Brian"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with user "Brian"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
+    Then the activity number 1 should have a message saying that user "Alice Hansen" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
     When the user filters activity list by "Activities by you"
     Then the activity should not have any message with keyword "shared"
     When the user filters activity list by "Shares"
-    Then the activity number 1 should have a message saying that user "User Zero" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
+    Then the activity number 1 should have a message saying that user "Alice Hansen" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
 
   Scenario: Sharing a file/folder with a group should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user0" has shared file "textfile0.txt" with group "grp1"
-    And user "user0" has shared folder "folder with space" with group "grp1"
-    And user "user0" has shared file "simple-folder/lorem.txt" with group "grp1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "grp1"
-    And user "user1" has logged in using the webUI
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Alice" has shared folder "folder with space" with group "grp1"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with group "grp1"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with group "grp1"
+    And user "Brian" has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
+    Then the activity number 1 should have a message saying that user "Alice Hansen" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
     When the user filters activity list by "Activities by you"
     Then the activity should not have any message with keyword "shared"
     When the user filters activity list by "Shares"
-    Then the activity number 1 should have a message saying that user "User Zero" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
+    Then the activity number 1 should have a message saying that user "Alice Hansen" has shared "simple-empty-folder, lorem.txt, folder with space and textfile0.txt" with you
 
   Scenario: Sharing a file/folder with a user should not be listed in the activity list stream when shared activity has been disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
-      | user1    |
-      | user2    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user0" has shared folder "folder with space" with user "user2"
-    And user "user0" has shared file "simple-folder/lorem.txt" with user "user1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with user "user2"
-    And user "user0" has logged in using the webUI
+      | Brian    |
+      | Carol    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared folder "folder with space" with user "Carol"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with user "Brian"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with user "Carol"
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "shared" using the webUI
     And the user browses to the activity page
@@ -105,245 +105,245 @@ Feature: Sharing file/folders activities
   Scenario: Sharing a file/folder with a group should not be listed in the activity list stream when shared activity has been disabled
     Given group "grp1" has been created
     And group "grp2" has been created
-    And user "user0" has shared file "textfile0.txt" with group "grp1"
-    And user "user0" has shared folder "folder with space" with group "grp2"
-    And user "user0" has shared file "simple-folder/lorem.txt" with group "grp1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "grp2"
-    And user "user0" has logged in using the webUI
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Alice" has shared folder "folder with space" with group "grp2"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with group "grp1"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with group "grp2"
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "shared" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "shared"
 
   Scenario: Receiving a file/folder from a sharer should not be listed in the activity list stream when shared activity has been disabled
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user0" has shared folder "folder with space" with user "user1"
-    And user "user0" has shared file "simple-folder/lorem.txt" with user "user1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with user "user1"
-    And user "user1" has logged in using the webUI
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared folder "folder with space" with user "Brian"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with user "Brian"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "shared" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "shared"
 
   Scenario: Receiving a file/folder in a group as a share should not be listed in the activity list stream when shared activity has been disabled
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user0" has shared file "textfile0.txt" with group "grp1"
-    And user "user0" has shared folder "folder with space" with group "grp1"
-    And user "user0" has shared file "simple-folder/lorem.txt" with group "grp1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "grp1"
-    And user "user1" has logged in using the webUI
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Alice" has shared folder "folder with space" with group "grp1"
+    And user "Alice" has shared file "simple-folder/lorem.txt" with group "grp1"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with group "grp1"
+    And user "Brian" has logged in using the webUI
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "shared" using the webUI
     And the user browses to the activity page
     Then the activity should not have any message with keyword "shared"
 
   Scenario: Uploading a file inside a shared folder by a sharee should be listed in the activity list of a sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/textfilemoved.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/textfilemoved.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User One" created "textfilemoved.txt"
+    Then the activity number 1 should have a message saying that user "Brian Murphy" created "textfilemoved.txt"
 
   Scenario: Creating a folder inside a shared folder by a sharee should be listed in the activity list of a sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user1" has created folder "simple-folder/newFolder"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Brian" has created folder "simple-folder/newFolder"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User One" created "newFolder"
+    Then the activity number 1 should have a message saying that user "Brian Murphy" created "newFolder"
 
   Scenario: Uploading a file inside a shared folder by a sharer should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/textfilemoved.txt"
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/textfilemoved.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" created "textfilemoved.txt"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" created "textfilemoved.txt"
 
   Scenario: Creating a folder inside a shared folder by a sharer should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has created folder "simple-folder/newFolder"
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has created folder "simple-folder/newFolder"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" created "newFolder"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" created "newFolder"
 
   Scenario: Deleting a file inside a shared folder by a sharee should be listed in the activity list of a sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user1" has deleted file "simple-folder/lorem.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Brian" has deleted file "simple-folder/lorem.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User One" deleted "lorem.txt"
+    Then the activity number 1 should have a message saying that user "Brian Murphy" deleted "lorem.txt"
 
   Scenario: Deleting a folder inside a shared folder by a sharee should be listed in the activity list of a sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user1" has deleted folder "simple-folder/simple-empty-folder"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Brian" has deleted folder "simple-folder/simple-empty-folder"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User One" deleted "simple-empty-folder"
+    Then the activity number 1 should have a message saying that user "Brian Murphy" deleted "simple-empty-folder"
 
   Scenario: Deleting a file inside a shared folder by a sharer should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has deleted file "simple-folder/lorem.txt"
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has deleted file "simple-folder/lorem.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" deleted "lorem.txt"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" deleted "lorem.txt"
 
   Scenario: Deleting a folder inside a shared folder by a sharer should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has deleted folder "simple-folder/simple-empty-folder"
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has deleted folder "simple-folder/simple-empty-folder"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" deleted "simple-empty-folder"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" deleted "simple-empty-folder"
 
   Scenario: Changing a shared file by a sharee should be listed in the activity list of a sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared file "lorem.txt" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user1" has uploaded file "filesForUpload/new-lorem-big.txt" to "lorem.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "lorem.txt" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Brian" has uploaded file "filesForUpload/new-lorem-big.txt" to "lorem.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User One" changed "lorem.txt"
+    Then the activity number 1 should have a message saying that user "Brian Murphy" changed "lorem.txt"
 
   Scenario: Changing a file inside a shared folder by a sharee should be listed in the activity list of a sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user1" has uploaded file "filesForUpload/new-lorem-big.txt" to "simple-folder/lorem.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Brian" has uploaded file "filesForUpload/new-lorem-big.txt" to "simple-folder/lorem.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User One" changed "lorem.txt"
+    Then the activity number 1 should have a message saying that user "Brian Murphy" changed "lorem.txt"
 
   Scenario: Changing a shared file by a sharer should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared file "lorem.txt" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "lorem.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "lorem.txt" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has uploaded file "filesForUpload/new-lorem-big.txt" to "lorem.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" changed "lorem.txt"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" changed "lorem.txt"
 
   Scenario: Changing a file inside a shared folder by a sharer should be listed in the activity list of a sharee
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has uploaded file "filesForUpload/new-lorem-big.txt" to "simple-folder/lorem.txt"
+    Given user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has uploaded file "filesForUpload/new-lorem-big.txt" to "simple-folder/lorem.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" changed "lorem.txt"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" changed "lorem.txt"
 
   Scenario: Creating a folder inside a shared folder by a sharer should be listed in the activity list of a sharee even after the sharee has unshared the share
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has created folder "simple-folder/newFolder"
-    And user "user1" has declined the share "/simple-folder" offered by user "user0"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has created folder "simple-folder/newFolder"
+    And user "Brian" has declined the share "/simple-folder" offered by user "Alice"
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" created "newFolder"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" created "newFolder"
 
   Scenario: Creating a folder inside a shared folder by a sharee should be listed in the activity list of a sharer even after the sharee has unshared the share
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user1" has created folder "simple-folder/newFolder"
-    And user "user1" has declined the share "/simple-folder" offered by user "user0"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Brian" has created folder "simple-folder/newFolder"
+    And user "Brian" has declined the share "/simple-folder" offered by user "Alice"
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User One" created "newFolder"
+    Then the activity number 1 should have a message saying that user "Brian Murphy" created "newFolder"
 
   Scenario: Deleting a share by a sharer should be listed in the activity list of the sharee
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user0" has deleted the last share
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Alice" has deleted the last share
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that "User Zero" removed the share for "simple-folder"
+    Then the activity number 1 should have a message saying that "Alice Hansen" removed the share for "simple-folder"
 
   Scenario: Deleting a share by a sharer should be listed in the activity list of the sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared folder "simple-folder" with user "user1"
-    And user "user0" has logged in using the webUI
-    And user "user0" has deleted the last share
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
+    And user "Alice" has deleted the last share
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that you removed the share of "User One" for "simple-folder"
+    Then the activity number 1 should have a message saying that you removed the share of "Brian Murphy" for "simple-folder"
 
   @issue-752 @skipOnOcV10.2
   Scenario: Sharer and sharee check activity after sharee unshares a shared file
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user1" has logged in using the webUI
-    And user "user1" has unshared file "textfile0.txt"
+      | Brian    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And user "Brian" has unshared file "textfile0.txt"
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "User Zero" from self
-    And the activity number 2 should contain message "User Zero shared textfile0.txt with you" in the activity page
-    When the user re-logs in as "user0" using the webUI
+    Then the activity number 1 should have a message saying that you have unshared file "textfile0.txt" shared by "Alice Hansen" from self
+    And the activity number 2 should contain message "Alice Hansen shared textfile0.txt with you" in the activity page
+    When the user re-logs in as "Alice" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User One"
+    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy"
 
   Scenario: Sharing a file/folder with a user should be listed in the activity tab of the sharer for the file
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
-      | user1    |
-      | user2    |
-    And user "user0" has shared file "block-aligned.txt" with user "user1"
-    And user "user0" has shared folder "folder with space" with user "user2"
-    And user "user0" has logged in using the webUI
+      | Brian    |
+      | Carol    |
+    And user "Alice" has shared file "block-aligned.txt" with user "Brian"
+    And user "Alice" has shared folder "folder with space" with user "Carol"
+    And user "Alice" has logged in using the webUI
     When the user browses directly to display the details of file "block-aligned.txt" in folder "/"
-    Then the activity number 1 should have message saying that the file is shared with user "User One" in the activity tab
+    Then the activity number 1 should have message saying that the file is shared with user "Brian Murphy" in the activity tab
     And the activity number 2 should contain message "You created block-aligned.txt" in the activity tab
     When the user opens the file action menu of folder "folder with space" on the webui
     And the user clicks the details file action on the webui
-    Then the activity number 1 should have message saying that the folder is shared with user "User Two" in the activity tab
+    Then the activity number 1 should have message saying that the folder is shared with user "Carol King" in the activity tab
     And the activity number 2 should contain message "You created folder with space" in the activity tab
 
   Scenario: Sharing a file/folder with a user should be listed in the activity tab of the sharee for the file
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user0" has shared file "block-aligned.txt" with user "user1"
-    And user "user0" has shared folder "folder with space" with user "user1"
-    And user "user1" has logged in using the webUI
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "block-aligned.txt" with user "Brian"
+    And user "Alice" has shared folder "folder with space" with user "Brian"
+    And user "Brian" has logged in using the webUI
     When the user browses directly to display the details of file "block-aligned.txt" in folder "/"
-    Then the activity number 1 should have message saying that the file is shared by user "User Zero" in the activity tab
+    Then the activity number 1 should have message saying that the file is shared by user "Alice Hansen" in the activity tab
     When the user opens the file action menu of folder "folder with space" on the webui
     And the user clicks the details file action on the webui
-    Then the activity number 1 should have message saying that the folder is shared by user "User Zero" in the activity tab
+    Then the activity number 1 should have message saying that the folder is shared by user "Alice Hansen" in the activity tab
 
   @issue-695
   Scenario: Sharing a file with a user should be listed in the activity list of a sharer
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user0" has shared file "textfile0.txt" with user "user2"
-    And user "user0" has logged in using the webUI
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared file "textfile0.txt" with user "Carol"
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "User Two"
+    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "Carol King"
     #remove the above step when issue is fixed
-    #Then the activity number 1 should contain message "You shared textfile0.txt with User One and User Two" in the activity page
+    #Then the activity number 1 should contain message "You shared textfile0.txt with Alice Hansen and Carol King" in the activity page
 
   Scenario: users checks a group related activity after deleting the group
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
+      | Brian    |
     And group "grp1" has been created
-    And user "user0" has been added to group "grp1"
-    And user "user1" has been added to group "grp1"
-    And user "user0" has shared file "textfile0.txt" with group "grp1"
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And group "grp1" has been deleted
-    And user "user0" has logged in using the webUI
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
     Then the activity number 1 should contain message "You shared textfile0.txt with group grp1" in the activity page
 
   Scenario: users checks a user related activity after deleting the user
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And user "user0" has shared file "textfile0.txt" with user "user1"
-    And user "user1" has been deleted
-    And user "user0" has logged in using the webUI
+      | Brian    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has been deleted
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "user1"
+    Then the activity number 1 should have a message saying that you have shared file "textfile0.txt" with user "Brian"

--- a/tests/acceptance/features/webUIActivityTags/tags.feature
+++ b/tests/acceptance/features/webUIActivityTags/tags.feature
@@ -5,11 +5,11 @@ Feature: Tag files/folders activities
   So that I know what happened in my cloud storage
 
   Scenario Outline: Adding a tag on a file/folder should be listed on the activity list
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
-    And user "user0" has created a "normal" tag with name "lorem"
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
+    And user "Alice" has created a "normal" tag with name "lorem"
     # <filepath> already has an ending slash('/')
-    And user "user0" has added tag "lorem" to file "<filepath><filename>"
+    And user "Alice" has added tag "lorem" to file "<filepath><filename>"
     When the user browses to the activity page
     Then the activity number 1 should contain message "You assigned system tag lorem to <filename>" in the activity page
     Examples:
@@ -24,22 +24,22 @@ Feature: Tag files/folders activities
   Scenario Outline: Adding a tag on the shared file/folder should be listed on the activity list
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user0    |
-      | user1    |
+      | Alice    |
+      | Brian    |
     And group "group1" has been created
-    And user "user0" has been added to group "group1"
-    And user "user1" has been added to group "group1"
-    And user "user0" has created a "normal" tag with name "lorem"
-    And user "user0" has shared file "<filename>" with group "group1"
-    And user "user0" has added tag "lorem" to file "<filename>"
-    And user "user0" has logged in using the webUI
+    And user "Alice" has been added to group "group1"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has created a "normal" tag with name "lorem"
+    And user "Alice" has shared file "<filename>" with group "group1"
+    And user "Alice" has added tag "lorem" to file "<filename>"
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
     Then the activity number 1 should have message "You assigned system tag lorem to <filename>" in the activity page
     And the activity number 2 should have message "You shared <filename> with group group1" in the activity page
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User Zero assigned system tag lorem to <filename>" in the activity page
-    And the activity number 2 should contain message "User Zero shared <filename> with you" in the activity page
+    Then the activity number 1 should contain message "Alice Hansen assigned system tag lorem to <filename>" in the activity page
+    And the activity number 2 should contain message "Alice Hansen shared <filename> with you" in the activity page
     Examples:
       | filename      |
       | lorem.txt     |
@@ -48,21 +48,21 @@ Feature: Tag files/folders activities
   Scenario Outline: tagging activity before sharing should not be listed for the share receiver.
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user0    |
-      | user1    |
+      | Alice    |
+      | Brian    |
     And group "group1" has been created
-    And user "user0" has been added to group "group1"
-    And user "user1" has been added to group "group1"
-    And user "user0" has created a "normal" tag with name "lorem"
-    And user "user0" has added tag "lorem" to file "<filename>"
-    And user "user0" has shared entry "<filename>" with group "group1"
-    And user "user0" has logged in using the webUI
+    And user "Alice" has been added to group "group1"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has created a "normal" tag with name "lorem"
+    And user "Alice" has added tag "lorem" to file "<filename>"
+    And user "Alice" has shared entry "<filename>" with group "group1"
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
     Then the activity number 1 should have message "You shared <filename> with group group1" in the activity page
     And the activity number 2 should have message "You assigned system tag lorem to <filename>" in the activity page
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User Zero shared <filename> with you" in the activity page
+    Then the activity number 1 should contain message "Alice Hansen shared <filename> with you" in the activity page
     And the activity should not have any message with keyword "system tag lorem"
     Examples:
       | filename      |
@@ -70,68 +70,68 @@ Feature: Tag files/folders activities
       | simple-folder |
 
   Scenario Outline: Activity for tagging a shared file/folder by sharee should be listed for sharer as well
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "group1" has been created
-    And user "user0" has been added to group "group1"
-    And user "user1" has been added to group "group1"
-    And user "user0" has shared file "<filename>" with group "group1"
-    And user "user1" has created a "normal" tag with name "lorem"
-    And user "user1" has added tag "lorem" to file "<filename>"
-    And user "user0" has logged in using the webUI
+    And user "Alice" has been added to group "group1"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has shared file "<filename>" with group "group1"
+    And user "Brian" has created a "normal" tag with name "lorem"
+    And user "Brian" has added tag "lorem" to file "<filename>"
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should contain message "User One assigned system tag lorem to <filename>" in the activity page
+    Then the activity number 1 should contain message "Brian Murphy assigned system tag lorem to <filename>" in the activity page
     And the activity number 2 should have message "You shared <filename> with group group1" in the activity page
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
     Then the activity number 1 should have message "You assigned system tag lorem to <filename>" in the activity page
-    And the activity number 2 should contain message "User Zero shared <filename> with you" in the activity page
+    And the activity number 2 should contain message "Alice Hansen shared <filename> with you" in the activity page
     Examples:
       | filename      |
       | lorem.txt     |
       | simple-folder |
 
   Scenario: Activity for tagging a reshared folder by sharee should be listed for original sharer as well
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "group1" has been created
-    And user "user0" has been added to group "group1"
-    And user "user1" has been added to group "group1"
-    And user "user0" has shared folder "simple-folder/simple-empty-folder" with group "group1"
-    And user "user1" has shared folder "simple-empty-folder" with user "user2"
-    And user "user2" has created a "normal" tag with name "simple"
-    And user "user2" has added tag "simple" to folder "simple-empty-folder"
-    And user "user0" has logged in using the webUI
+    And user "Alice" has been added to group "group1"
+    And user "Brian" has been added to group "group1"
+    And user "Alice" has shared folder "simple-folder/simple-empty-folder" with group "group1"
+    And user "Brian" has shared folder "simple-empty-folder" with user "Carol"
+    And user "Carol" has created a "normal" tag with name "simple"
+    And user "Carol" has added tag "simple" to folder "simple-empty-folder"
+    And user "Alice" has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should contain message "User Two assigned system tag simple to simple-empty-folder" in the activity page
-    And the activity number 2 should have a message saying that user "User One" has shared "simple-empty-folder" with user "User Two"
+    Then the activity number 1 should contain message "Carol King assigned system tag simple to simple-empty-folder" in the activity page
+    And the activity number 2 should have a message saying that user "Brian Murphy" has shared "simple-empty-folder" with user "Carol King"
     And the activity number 3 should have message "You shared simple-empty-folder with group group1" in the activity page
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "Brian" using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should contain message "User Two assigned system tag simple to simple-empty-folder" in the activity page
-    And the activity number 2 should have a message saying that you have shared folder "simple-empty-folder" with user "User Two"
-    And the activity number 3 should have a message saying that user "User Zero" has shared "simple-empty-folder" with you
-    When the user re-logs in as "user2" using the webUI
+    Then the activity number 1 should contain message "Carol King assigned system tag simple to simple-empty-folder" in the activity page
+    And the activity number 2 should have a message saying that you have shared folder "simple-empty-folder" with user "Carol King"
+    And the activity number 3 should have a message saying that user "Alice Hansen" has shared "simple-empty-folder" with you
+    When the user re-logs in as "Carol" using the webUI
     And the user browses to the activity page
     Then the activity number 1 should have message "You assigned system tag simple to simple-empty-folder" in the activity page
-    And the activity number 2 should have a message saying that user "User One" has shared "simple-empty-folder" with you
-    And the activity should not have any message with keyword "User Zero"
+    And the activity number 2 should have a message saying that user "Brian Murphy" has shared "simple-empty-folder" with you
+    And the activity should not have any message with keyword "Alice Hansen"
 
   Scenario: Activity for creating a normal system tag by a user should be listed in activity list of an admin
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has created a "normal" tag with name "lorem"
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has created a "normal" tag with name "lorem"
     And the administrator has logged in using the webUI
     When the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" created system tag "lorem"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" created system tag "lorem"
 
   Scenario: Activity for deleting a normal system tag by a user should be listed in activity list of an admin
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has created a "normal" tag with name "lorem"
-    When user "user0" deletes the tag with name "lorem" using the WebDAV API
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has created a "normal" tag with name "lorem"
+    When user "Alice" deletes the tag with name "lorem" using the WebDAV API
     And the administrator logs in using the webUI
     And the user browses to the activity page
-    Then the activity number 1 should have a message saying that user "User Zero" deleted system tag "lorem"
+    Then the activity number 1 should have a message saying that user "Alice Hansen" deleted system tag "lorem"
 
   Scenario: Activity for creating a static system tag by a administrator should be listed in activity list of an admin
     Given the administrator has created a "static" tag with name "StaticTagName"
@@ -149,11 +149,11 @@ Feature: Tag files/folders activities
   @skipOnFIREFOX
   # Firefox does not auto-scroll to click the checkbox for 'disables activity log stream for "systemtags"'
   Scenario Outline: Adding a tag on a file/folder should not be listed in the activity list stream when system tags activity has been disabled
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
-    And user "user0" has created a "normal" tag with name "lorem"
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
+    And user "Alice" has created a "normal" tag with name "lorem"
     # <filepath> already has an ending slash('/')
-    And user "user0" has added tag "lorem" to file "<filepath><filename>"
+    And user "Alice" has added tag "lorem" to file "<filepath><filename>"
     And the user has browsed to the personal general settings page
     When the user disables activity log stream for "systemtags" using the webUI
     And the user browses to the activity page
@@ -168,19 +168,19 @@ Feature: Tag files/folders activities
       | 'single'quotes/simple-empty-folder/ | for-git-commit      |
 
   Scenario: Adding a tag on a file/folder should be listed on the activity tab
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has logged in using the webUI
-    And user "user0" has created a "normal" tag with name "lorem"
-    And user "user0" has added tag "lorem" to file "lorem.txt"
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has logged in using the webUI
+    And user "Alice" has created a "normal" tag with name "lorem"
+    And user "Alice" has added tag "lorem" to file "lorem.txt"
     When the user browses directly to display the details of file "lorem.txt" in folder "/"
     Then the activity number 1 should contain message "You assigned system tag lorem" in the activity tab
     And the activity number 2 should contain message "You created lorem.txt" in the activity tab
 
   Scenario: Administrator checks the activity of user after deleting the user
-    Given user "user0" has been created with default attributes and skeleton files
-    And user "user0" has created a "normal" tag with name "StaticTagName"
-    And user "user0" has been deleted
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has created a "normal" tag with name "StaticTagName"
+    And user "Alice" has been deleted
     And the administrator logs in using the webUI
     And the user browses to the activity page
     # DisplayName is not available when the user is deleted.
-    Then the activity number 1 should have message "Uuser0 created system tag StaticTagName" in the activity page
+    Then the activity number 1 should have message "AAlice created system tag StaticTagName" in the activity page


### PR DESCRIPTION
like in core PR https://github.com/owncloud/core/pull/37397

IMO this can be done as a background task in apps with acceptance tests. It seems to be as easy as:
replace `user0` with `Alice`
replace `User Zero` with `Alice Hansen`
replace `user1` with `Brian`
replace `User One` with `Brian Murphy`
...

Then search for "unfortunate" replacements like `$Brian` or `:Brian` that use to be `$user1` or `:user1` and put them back (or name the variables something else).

https://doc.owncloud.com/server/developer_manual/testing/acceptance-tests.html#specifying-the-actor has the table of "standard" user names, display names and email addresses.