### PR TITLE
 files/folders in html emails are now clickable

### DIFF
--- a/lib/HtmlTextParser.php
+++ b/lib/HtmlTextParser.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Thomas Müller <1005065+DeepDiver1975@users.noreply.github.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Activity;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class HtmlTextParser extends PlainTextParser {
+
+	/**
+	 * @var IURLGenerator
+	 */
+	private $generator;
+
+	public function __construct(IL10N $l, IURLGenerator $generator) {
+		parent::__construct($l);
+		$this->generator = $generator;
+	}
+
+	/**
+	 * Display the path for files
+	 *
+	 * @param string $message
+	 * @return string
+	 */
+	protected function parseFileParameters($message) {
+		return \preg_replace_callback('/<file\ link=\"(.*?)\"\ id=\"(.*?)\">(.*?)<\/file>/', function ($match) {
+			$privateLink = $this->generator->getAbsoluteURL("/index.php/f/{$match[2]}");
+			return "<a href=\"$privateLink\">{$match[3]}</a>";
+		}, $message);
+	}
+}

--- a/templates/email.notification.php
+++ b/templates/email.notification.php
@@ -1,5 +1,5 @@
 <?php
-/** @var OC_L10N $l */
+/** @var \OCP\IL10N $l */
 /** @var array $_ */
 $l = $_['overwriteL10N'];
 

--- a/tests/Unit/Parsers/HtmlTextParserTest.php
+++ b/tests/Unit/Parsers/HtmlTextParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OCA\Activity\Tests\Unit\Parsers;
+
+use OCA\Activity\HtmlTextParser;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use Test\TestCase;
+
+class HtmlTextParserTest extends TestCase {
+
+	/**
+	 * @dataProvider providesMessages
+	 * @param string $expected
+	 * @param string $message
+	 */
+	public function test(string $expected, string $message): void {
+		$l = $this->createMock(IL10N::class);
+		$g = $this->createMock(IURLGenerator::class);
+		$g->method('getAbsoluteURL')->willReturnCallback(static function ($url) {
+			return 'https://cloud.example.net' . $url;
+		});
+		$p = new HtmlTextParser($l, $g);
+		$parsed = $p->parseMessage($message);
+		self::assertEquals($expected, $parsed);
+	}
+
+	public function providesMessages(): array {
+		return [
+			['You deleted <a href="https://cloud.example.net/index.php/f/123456">bar.txt</a>', 'You deleted <file link="https://cloud.example.net/foo/bar.txt" id="123456">bar.txt</file>']
+		];
+	}
+}


### PR DESCRIPTION
Fixes https://jira.owncloud.com/browse/OC-2285

## Screenshot

![Screenshot_2020-10-14 MailHog](https://user-images.githubusercontent.com/4378513/96011795-ae9c2b00-0e43-11eb-812f-e6438964f709.png)

### Url Format
`<a href="http://localhost/index.php/f/127">Screenshot_2020-02-26 Document Classification app ownCloud marketplace.png</a>`