### PR TITLE
Support extraApps in drone phpstan()

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -280,6 +280,7 @@ def phpstan():
 	default = {
 		'phpVersions': ['7.2'],
 		'logLevel': '2',
+		'extraApps': {},
 	}
 
 	if 'defaults' in config:
@@ -319,6 +320,7 @@ def phpstan():
 				'steps':
 					installCore('daily-master-qa', 'sqlite', False) +
 					installApp(phpVersion) +
+					installExtraApps(phpVersion, params['extraApps']) +
 					setupServerAndApp(phpVersion, params['logLevel']) +
 				[
 					{


### PR DESCRIPTION
This was introduced in https://github.com/owncloud/files_ldap_home/pull/28

Add it here in `activity` so that the drone code will be noticed and copied to other apps next time stuff changes.