### PR TITLE
Change TEST_EXTERNAL_USER_BACKENDS to TEST_WITH_LDAP

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -906,7 +906,7 @@ def acceptance():
 									environment['MAILHOG_HOST'] = 'email'
 
 								if params['ldapNeeded']:
-									environment['TEST_EXTERNAL_USER_BACKENDS'] = True
+									environment['TEST_WITH_LDAP'] = True
 
 								if (cephS3Needed or scalityS3Needed):
 									environment['OC_TEST_ON_OBJECTSTORE'] = '1'


### PR DESCRIPTION
To match the change in core PR https://github.com/owncloud/core/pull/38077

Note: this PR is to get the "standard" drone starlark up-to-date. This env var is not actually used by the activity app CI. I will also change it in `user_ldap`  where it matters...

The change will get propagated to the other ownCloud10 app repos the next time there is an important change needed.