### PR TITLE
[tests-only] Run unit tests with mysql:8.0 in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -638,7 +638,7 @@ def phpTests(ctx, testType):
 	default = {
 		'phpVersions': ['7.2', '7.3', '7.4'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
+			'sqlite', 'mariadb:10.2', 'mysql:8.0', 'postgres:9.4', 'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,
@@ -1138,7 +1138,7 @@ def notify():
 def databaseService(db):
 	dbName = getDbName(db)
 	if (dbName == 'mariadb') or (dbName == 'mysql'):
-		return [{
+		service = {
 			'name': dbName,
 			'image': db,
 			'pull': 'always',
@@ -1148,7 +1148,10 @@ def databaseService(db):
 				'MYSQL_DATABASE': getDbDatabase(db),
 				'MYSQL_ROOT_PASSWORD': getDbRootPassword()
 			}
-		}]
+		}
+		if (db == 'mysql:8.0'):
+			service['command'] = ['--default-authentication-plugin=mysql_native_password']
+		return [service]
 
 	if dbName == 'postgres':
 		return [{

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,5 +29,5 @@ sonar.pullrequest.branch=${env.SONAR_PULL_REQUEST_BRANCH}
 sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 
 # Properties specific to language plugins:
-sonar.php.coverage.reportPaths=results/clover-phpunit-php7.2-mariadb10.2.xml,results/clover-phpunit-php7.2-mysql5.5.xml,results/clover-phpunit-php7.2-mysql5.7.xml,results/clover-phpunit-php7.2-postgres9.4.xml,results/clover-phpunit-php7.2-oracle.xml,results/clover-phpunit-php7.2-sqlite.xml
+sonar.php.coverage.reportPaths=results/clover-phpunit-php7.2-mariadb10.2.xml,results/clover-phpunit-php7.2-mysql8.0.xml,results/clover-phpunit-php7.2-postgres9.4.xml,results/clover-phpunit-php7.2-oracle.xml,results/clover-phpunit-php7.2-sqlite.xml
 sonar.javascript.lcov.reportPaths=results/lcov.info


### PR DESCRIPTION
The officially-supported mySQL is V8. Run unit tests with mySQL V8 rather than V5.*