### PR TITLE
[tests-only] Add starlark code to handle the case when a repo has no code coverage tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -140,8 +140,11 @@ def main(ctx):
 
 	dependsOn(before, stages)
 
-	afterCoverageTests = afterCoveragePipelines(ctx)
-	dependsOn(coverageTests, afterCoverageTests)
+	if (coverageTests == []):
+		afterCoverageTests = []
+	else:
+		afterCoverageTests = afterCoveragePipelines(ctx)
+		dependsOn(coverageTests, afterCoverageTests)
 
 	after = afterPipelines(ctx)
 	dependsOn(afterCoverageTests + stages, after)


### PR DESCRIPTION
For example, https://github.com/owncloud/theme-enterprise/pull/88 - that repo has no JS or PHP unit tests. The previous starlark code was still running sonar-analysis, which failed because there are no coverage results...

For "non-code" repos like that, we do not need to do sonar-analysis at all. Add logic to `.drone.star` to handle that case.