### PR TITLE
[tests-only] Bump minio/mc to latest docker tag

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1045,7 +1045,7 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 		[
 			{
 				'name': 'sync-from-cache',
-				'image': 'minio/mc:RELEASE.2020-12-10T01-26-17Z',
+				'image': 'minio/mc:RELEASE.2020-12-18T10-53-53Z',
 				'pull': 'always',
 				'environment': {
 					'MC_HOST_cache': {
@@ -1087,7 +1087,7 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 			},
 			{
 				'name': 'purge-cache',
-				'image': 'minio/mc:RELEASE.2020-12-10T01-26-17Z',
+				'image': 'minio/mc:RELEASE.2020-12-18T10-53-53Z',
 				'environment': {
 					'MC_HOST_cache': {
 						'from_secret': 'cache_s3_connection_url'


### PR DESCRIPTION
`minio/mc` fixed their broken release. We may as well bump to the latest tag available at https://hub.docker.com/r/minio/mc/tags?page=1&ordering=last_updated

Just do this in the `activity` app. Next time we update `.drone.star` to all other apps, we will get this non-essential change.