### PR TITLE
[tests-only] skip core app-required scenarios

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -79,6 +79,7 @@ config = {
 			'cron': 'nightly',
 			'runAllSuites': True,
 			'numberOfParts': 35,
+			'filterTags': '~@skip&&~@app-required',
 		},
 		'core-cli-acceptance': {
 			'suites': {
@@ -98,6 +99,7 @@ config = {
 			'runAllSuites': True,
 			'numberOfParts': 3,
 			'emailNeeded': True,
+			'filterTags': '~@skip&&~@app-required',
 		},
 		'core-webui-acceptance': {
 			'suites': {
@@ -118,7 +120,7 @@ config = {
 			'cron': 'nightly',
 			'runAllSuites': True,
 			'numberOfParts': 5,
-			'filterTags': '@smokeTest&&~@skip',
+			'filterTags': '@smokeTest&&~@skip&&~@app-required',
 		}
 	}
 }


### PR DESCRIPTION
Any core test scenario that is tagged `@app-required` is a test scenario that needs some non-core app to be installed and enabled. To run those scenarios requires that CI have code to install and enable the needed app(s).

For pipelines that do a general run of core scenarios, skip those scenarios.