### PR TITLE
[tests-only] Adjust pullRequestAndCron logic in .drone.star

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1017,17 +1017,11 @@ def acceptance(ctx):
 					'trigger': {}
 				}
 
-				if (testConfig['pullRequestAndCron'] != ''):
-					if ctx.build.event == 'pull_request':
-						result['trigger']['ref'] = [
-							'refs/pull/**',
-							'refs/tags/**'
-						]
-					else:
-						result['trigger']['cron'] = testConfig['pullRequestAndCron']
+				if (testConfig['cron'] != ''):
+					result['trigger']['cron'] = testConfig['cron']
 				else:
-					if (testConfig['cron'] != ''):
-						result['trigger']['cron'] = testConfig['cron']
+					if ((testConfig['pullRequestAndCron'] != '') and (ctx.build.event != 'pull_request')):
+						result['trigger']['cron'] = testConfig['pullRequestAndCron']
 					else:
 						result['trigger']['ref'] = [
 							'refs/pull/**',

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "behat/behat": "^3.6",
+        "behat/behat": "^3.8",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",

--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "squizlabs/php_codesniffer": "3.*"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "conflict": {
         "squizlabs/php_codesniffer": "3.5.1"


### PR DESCRIPTION
Adjust the logic so that setting `cron` parameter to `nightly` takes priority over the setting of `pullRequestAndCron` - if both are set then `cron` `nightly` will happen.

This is needed because the `pullRequestAndCron` parameter is set to `nightly` by default (which is the setting that we want most of the time).

Without this change, when setting `cron` to `nightly` you also would have to remember to set `pullRequestAndCron` to "" (the empty string). I noticed this when doing PR https://github.com/owncloud/admin_audit/pull/355 for admin_audit.