### PR TITLE
[tests-only] Use nodejs docker for JS tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -586,7 +586,7 @@ def javascript(ctx):
 		[
 			{
 				'name': 'js-tests',
-				'image': 'owncloudci/php:7.2',
+				'image': 'owncloudci/nodejs:12',
 				'pull': 'always',
 				'environment': params['extraEnvironment'],
 				'commands': params['extraCommandsBeforeTestRun'] + [

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 #
-# Define NPM and COMPOSER_BIN and check if they are available on the system.
+# Define NPM and check if it is available on the system.
 #
 SHELL := /bin/bash
-
-COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
-ifndef COMPOSER_BIN
-    $(error composer is not available on your system, please install composer)
-endif
 
 NPM := $(shell command -v npm 2> /dev/null)
 ifndef NPM


### PR DESCRIPTION
1) Use `owncloudci/nodejs:12` for JS  tests in CI to avoid stuff like https://drone.owncloud.com/owncloud/activity/1662/2/4
```
error karma@5.2.3: The engine "node" is incompatible with this module. Expected version ">= 10". Got "8.17.0"
```

Why have we been using `owncloudci/php` for this anyway? I don't know. It has https://github.com/owncloud-ci/php/blob/master/v7.2/Dockerfile.amd64 - `nodejs` v8 comes "by default" with Ubuntu 18.04, and that `nodejs` is getting too old.

2) Remove the check for `composer` from `Makefile`. `make test-js` does not need composer, and probably other `make` targets do not need it either.