### PR TITLE
[tests-only] Use latest docker CI images for Javascript pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -275,7 +275,7 @@ def jscodestyle():
 		'steps': [
 			{
 				'name': 'coding-standard-js',
-				'image': 'owncloudci/php:7.2',
+				'image': 'owncloudci/php:8.0',
 				'pull': 'always',
 				'commands': [
 					'make test-js-style'
@@ -580,13 +580,13 @@ def javascript(ctx):
 		},
 		'steps':
 			installCore('daily-master-qa', 'sqlite', False) +
-			installApp('7.2') +
-			setupServerAndApp('7.2', params['logLevel']) +
+			installApp('7.4') +
+			setupServerAndApp('7.4', params['logLevel']) +
 			params['extraSetup'] +
 		[
 			{
 				'name': 'js-tests',
-				'image': 'owncloudci/php:7.2',
+				'image': 'owncloudci/php:8.0',
 				'pull': 'always',
 				'environment': params['extraEnvironment'],
 				'commands': params['extraCommandsBeforeTestRun'] + [


### PR DESCRIPTION
The `owncloudci/php` docker image actually contains various other non-PHP tools tah tare used in CI. For example, `nodejs` and `npm` for Javascript. The latest `owncloudci/php:8.0` has newer versions of these packages. Use it for Javascipt CI pipelines.

This helps for other version bump PRs like #910 and https://github.com/owncloud/files_classifier/pull/428 that need a newer `nodejs` and `npm`