### PR TITLE
[tests-only] do not let someone accidentally commit a local .drone.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ tests/js/package-lock.json
 
 # SonarCloud scanner
 .scannerwork
+
+# drone CI is in .drone.star, do not let someone accidentally commit a local .drone.yml
+.drone.yml


### PR DESCRIPTION
When debugging what pipeline `.drone.star` actually produces, it is possibly to locally do:
```
drone starlark
```

And that produces a generated `.drone.yml` that you can examine.

We do not want people to accidentally commit that file.

Note: this is already ignored in `owncloud/core`
