### PR TITLE
Automations in activity stream

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -45,6 +45,9 @@ config = {
 				'chrome',
 				'firefox'
 			],
+			'servers': [
+				'daily-master-qa',
+			],
 		},
 		'federatedSuites': {
 			'suites': {
@@ -54,11 +57,17 @@ config = {
 				'chrome',
 				'firefox'
 			],
+			'servers': [
+				'daily-master-qa',
+			],
 			'federatedServerNeeded': True
 		},
 		'api': {
 			'suites': [
 				'apiActivity'
+			],
+			'servers': [
+				'daily-master-qa',
 			],
 		},
 		'core-api-acceptance': {

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@ Never again miss an important event related to content in ownCloud and always be
   <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/68550c2b7c53e6309132ca1c7b177adca976db0b/activity/activity.png</screenshot>
   <category>tools</category>
   <dependencies>
-    <owncloud min-version="10.2" max-version="10"/>
+    <owncloud min-version="10.7.1" max-version="10"/>
   </dependencies>
   <background-jobs>
     <job>OCA\Activity\BackgroundJob\EmailNotification</job>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -68,7 +68,8 @@ class Application extends App {
 			return new Consumer(
 				$c->query('ActivityData'),
 				$c->query('UserSettings'),
-				$server->getL10NFactory()
+				$server->getL10NFactory(),
+				$c->query('OCP\Activity\IManager')
 			);
 		});
 

--- a/tests/Unit/ConsumerTest.php
+++ b/tests/Unit/ConsumerTest.php
@@ -44,6 +44,9 @@ class ConsumerTest extends TestCase {
 	/** @var \OCA\Activity\UserSettings */
 	protected $userSettings;
 
+	/** @var \OCP\Activity\IManager */
+	protected $manager;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->deleteTestActivities();
@@ -68,6 +71,10 @@ class ConsumerTest extends TestCase {
 			->method('get')
 			->with('activity')
 			->willReturn($l10n);
+
+		$this->manager = $this->getMockBuilder('OCP\Activity\IManager')
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->userSettings->expects($this->any())
 			->method('getUserSetting')
@@ -134,7 +141,7 @@ class ConsumerTest extends TestCase {
 				]
 			]);
 
-		$consumer = new Consumer($this->data, $this->userSettings, $this->l10nFactory);
+		$consumer = new Consumer($this->data, $this->userSettings, $this->l10nFactory, $this->manager);
 		$event = \OC::$server->getActivityManager()->generateEvent();
 		$event->setApp('test')
 			->setType($type)
@@ -178,7 +185,7 @@ class ConsumerTest extends TestCase {
 			]);
 
 		$time = \time();
-		$consumer = new Consumer($this->data, $this->userSettings, $this->l10nFactory);
+		$consumer = new Consumer($this->data, $this->userSettings, $this->l10nFactory, $this->manager);
 		$event = \OC::$server->getActivityManager()->generateEvent();
 		$event->setApp('test')
 			->setType($type)


### PR DESCRIPTION
These adjustments properly handle the activity stream for actions that were triggered by an automation (like the workflow app e.g.). They require the changes from https://github.com/owncloud/core/pull/38605 and https://github.com/owncloud/workflow/pull/255 to work.

Needed for: https://github.com/owncloud/enterprise/issues/4222