### PR TITLE
Remove unneeded HOSTNAME from ldapService

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -884,7 +884,7 @@ def acceptance(ctx):
 				suites[suite] = suite
 		else:
 			suites = matrix['suites']
-		
+
 		if 'debugSuites' in matrix and len(matrix['debugSuites']) != 0:
 			if type(matrix['debugSuites']) == "list":
 				suites = {}
@@ -1281,7 +1281,6 @@ def ldapService(ldapNeeded):
 				'LDAP_ORGANISATION': 'owncloud',
 				'LDAP_ADMIN_PASSWORD': 'admin',
 				'LDAP_TLS_VERIFY_CLIENT': 'never',
-				'HOSTNAME': 'ldap',
 			}
 		}]
 


### PR DESCRIPTION
Yesterday, we discovered that this actually causes a problem when used. See https://github.com/owncloud/user_ldap/pull/637/commits/95b7e4fd7616c7090284215ac95a165911bd7bc3 

Remove it from the "standard" `.drone.star` code here in the activity app so that we do not propagate the problem again.