### PR TITLE
[tests-only] Allow for no unit tests with coverage in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -144,6 +144,13 @@ def main(ctx):
 
 	dependsOn(before, coverageTests)
 
+	nonCoverageTests = nonCoveragePipelines(ctx)
+	if (nonCoverageTests == False):
+		print('Errors detected in nonCoveragePipelines. Review messages above.')
+		return []
+
+	dependsOn(before, nonCoverageTests)
+
 	stages = stagePipelines(ctx)
 	if (stages == False):
 		print('Errors detected. Review messages above.')
@@ -158,18 +165,28 @@ def main(ctx):
 		dependsOn(coverageTests, afterCoverageTests)
 
 	after = afterPipelines(ctx)
-	dependsOn(afterCoverageTests + stages, after)
+	dependsOn(afterCoverageTests + nonCoverageTests + stages, after)
 
-	return before + coverageTests + afterCoverageTests + stages + after
+	return before + coverageTests + afterCoverageTests + nonCoverageTests + stages + after
 
 def beforePipelines():
 	return codestyle() + jscodestyle() + phpstan() + phan()
 
 def coveragePipelines(ctx):
-	# All pipelines that might have coverage or other test analysis reported
-	jsPipelines = javascript(ctx)
-	phpUnitPipelines = phpTests(ctx, 'phpunit')
-	phpIntegrationPipelines = phpTests(ctx, 'phpintegration')
+	# All unit test pipelines that have coverage or other test analysis reported
+	jsPipelines = javascript(ctx, True)
+	phpUnitPipelines = phpTests(ctx, 'phpunit', True)
+	phpIntegrationPipelines = phpTests(ctx, 'phpintegration', True)
+	if (jsPipelines == False) or (phpUnitPipelines == False) or (phpIntegrationPipelines == False):
+		return False
+
+	return jsPipelines + phpUnitPipelines + phpIntegrationPipelines
+
+def nonCoveragePipelines(ctx):
+	# All unit test pipelines that do not have coverage or other test analysis reported
+	jsPipelines = javascript(ctx, False)
+	phpUnitPipelines = phpTests(ctx, 'phpunit', False)
+	phpIntegrationPipelines = phpTests(ctx, 'phpintegration', False)
 	if (jsPipelines == False) or (phpUnitPipelines == False) or (phpIntegrationPipelines == False):
 		return False
 
@@ -545,7 +562,7 @@ def build():
 
 	return pipelines
 
-def javascript(ctx):
+def javascript(ctx, withCoverage):
 	pipelines = []
 
 	if 'javascript' not in config:
@@ -581,6 +598,14 @@ def javascript(ctx):
 		params[item] = matrix[item] if item in matrix else default[item]
 
 	if params['skip']:
+		return pipelines
+
+	# if we only want pipelines with coverage, and this pipeline does not do coverage, then do not include it
+	if withCoverage and not params['coverage']:
+		return pipelines
+
+	# if we only want pipelines without coverage, and this pipeline does coverage, then do not include it
+	if not withCoverage and params['coverage']:
 		return pipelines
 
 	result = {
@@ -645,7 +670,7 @@ def javascript(ctx):
 
 	return [result]
 
-def phpTests(ctx, testType):
+def phpTests(ctx, testType, withCoverage):
 	pipelines = []
 
 	if testType not in config:
@@ -696,6 +721,14 @@ def phpTests(ctx, testType):
 			params[item] = matrix[item] if item in matrix else default[item]
 
 		if params['skip']:
+			continue
+
+		# if we only want pipelines with coverage, and this pipeline does not do coverage, then do not include it
+		if withCoverage and not params['coverage']:
+			continue
+
+		# if we only want pipelines without coverage, and this pipeline does coverage, then do not include it
+		if not withCoverage and params['coverage']:
 			continue
 
 		cephS3Params = params['cephS3']


### PR DESCRIPTION
Problem: Some JS and/or PHP test pipelines do not have coverage enabled. If there are no pipelines with coverage enabled, the sonar-analysis pipeline is still being added to CI. But it has nothing to do, and fails because it does not find any coverage results to process.

Solution: this PR refactors `.drone.star` so that it:
1) finds all JS and PHP test pipelines that do have coverage enabled
2) adds the sonar-analysis pipeline if (1) is non-empty
3) adds any JS and PHP test pipelines that do not have coverage enabled
4) continues adding the acceptance test pipelines.