### PR TITLE
Set the objectId for a received federated share activity

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -298,6 +298,8 @@ class Application extends App {
 		$eventDispatcher = $this->getContainer()->getServer()->getEventDispatcher();
 		$eventDispatcher->addListener('OCA\Files::loadAdditionalScripts', ['OCA\Activity\FilesHooksStatic', 'onLoadFilesAppScripts']);
 
+		$eventDispatcher->addListener('remoteshare.accepted', ['OCA\Activity\Hooks', 'onRemoteShareAccepted']);
+
 		Util::connectHook('OC_User', 'post_deleteUser', 'OCA\Activity\Hooks', 'deleteUser');
 
 		$this->registerFilesActivity();

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -211,7 +211,10 @@ class Data {
 		if ($filter === 'self') {
 			$query->andWhere($query->expr()->eq('user', $query->createNamedParameter($user)));
 		} elseif ($filter === 'by') {
-			$query->andWhere($query->expr()->neq('user', $query->createNamedParameter($user)));
+			$query->andWhere($query->expr()->orX(
+				$query->expr()->neq('user', $query->createNamedParameter($user)),
+				$query->expr()->isNull('user')
+			));
 		} elseif ($filter === 'all' && !$userSettings->getUserSetting($user, 'setting', 'self')) {
 			$query->andWhere($query->expr()->orX(
 				$query->expr()->neq('user', $query->createNamedParameter($user)),

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -79,6 +79,7 @@ class Hooks {
 	public static function onRemoteShareAccepted($params) {
 		$shareId = $params->getArgument('shareId');
 		$fileId = $params->getArgument('fileId');
+		$shareRecipient = $params->getArgument('shareRecipient');
 
 		if ($shareId === null || $fileId === null) {
 			return;
@@ -91,9 +92,17 @@ class Hooks {
 			->set('object_id', $queryBuilder->createNamedParameter($fileId))
 			->where($queryBuilder->expr()->eq('subject', $queryBuilder->createParameter('subject')))
 			->andWhere(
+				$queryBuilder->expr()->eq('affecteduser', $queryBuilder->createParameter('affecteduser'))
+			)
+			->andWhere(
+				$queryBuilder->expr()->like('object_id', $queryBuilder->createParameter('object_id'))
+			)
+			->andWhere(
 				$queryBuilder->expr()->like('subjectparams', $queryBuilder->createParameter('subjectparams'))
 			)
 			->setParameter('subject', Activity::SUBJECT_REMOTE_SHARE_RECEIVED)
+			->setParameter('affecteduser', $shareRecipient)
+			->setParameter('object_id', 0)
 			->setParameter('subjectparams', '%{"shareId":"' . $shareId . '"}%');
 
 		$queryBuilder->execute();

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -22,12 +22,15 @@
 namespace OCA\Activity;
 
 use OCA\Activity\AppInfo\Application;
+use OCA\Files_Sharing\Activity;
 use OCP\IDBConnection;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Handles the stream and mail queue of a user when he is being deleted
  */
 class Hooks {
+
 	/**
 	 * Delete remaining activities and emails when a user is deleted
 	 *
@@ -65,6 +68,34 @@ class Hooks {
 		$queryBuilder->delete('activity_mq')
 			->where($queryBuilder->expr()->eq('amq_affecteduser', $queryBuilder->createParameter('user')))
 			->setParameter('user', $user);
+		$queryBuilder->execute();
+	}
+
+	/**
+	 * Set the object ID for a received federated share activity.
+	 *
+	 * @param GenericEvent $params
+	 */
+	public static function onRemoteShareAccepted($params) {
+		$shareId = $params->getArgument('shareId');
+		$fileId = $params->getArgument('fileId');
+
+		if ($shareId === null || $fileId === null) {
+			return;
+		}
+
+		$connection = \OC::$server->getDatabaseConnection();
+		$queryBuilder = $connection->getQueryBuilder();
+
+		$queryBuilder->update('activity')
+			->set('object_id', $queryBuilder->createNamedParameter($fileId))
+			->where($queryBuilder->expr()->eq('subject', $queryBuilder->createParameter('subject')))
+			->andWhere(
+				$queryBuilder->expr()->like('subjectparams', $queryBuilder->createParameter('subjectparams'))
+			)
+			->setParameter('subject', Activity::SUBJECT_REMOTE_SHARE_RECEIVED)
+			->setParameter('subjectparams', '%{"shareId":"' . $shareId . '"}%');
+
 		$queryBuilder->execute();
 	}
 }


### PR DESCRIPTION
Before this fix, the objectId of a received federated share activity was empty. As a result, the activity was not showing in the file sidebar. We now set the objectId by updating the activity as soon as the share has been accepted by the user.

Also fixed a bug where certain activities were not showing in `Activities by others`.

- fixes https://github.com/owncloud/activity/issues/969
- fixes https://github.com/owncloud/activity/issues/970

- Depends on https://github.com/owncloud/core/pull/38880


![image](https://user-images.githubusercontent.com/50302941/123065694-adc68a80-d40f-11eb-93a5-269ba466438f.png)
