### PR TITLE
[tests-only] make code coverage report correctly on PRs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,5 +1,4 @@
 config = {
-	'app': 'activity',
 	'rocketchat': {
 		'channel': 'builds',
 		'from_secret': 'private_rocketchat'
@@ -135,7 +134,7 @@ config = {
 }
 
 def main(ctx):
-	before = beforePipelines()
+	before = beforePipelines(ctx)
 
 	coverageTests = coveragePipelines(ctx)
 	if (coverageTests == False):
@@ -169,8 +168,8 @@ def main(ctx):
 
 	return before + coverageTests + afterCoverageTests + nonCoverageTests + stages + after
 
-def beforePipelines():
-	return codestyle() + jscodestyle() + phpstan() + phan()
+def beforePipelines(ctx):
+	return codestyle(ctx) + jscodestyle(ctx) + phpstan(ctx) + phan(ctx)
 
 def coveragePipelines(ctx):
 	# All unit test pipelines that have coverage or other test analysis reported
@@ -193,7 +192,7 @@ def nonCoveragePipelines(ctx):
 	return jsPipelines + phpUnitPipelines + phpIntegrationPipelines
 
 def stagePipelines(ctx):
-	buildPipelines = build()
+	buildPipelines = build(ctx)
 	acceptancePipelines = acceptance(ctx)
 	if (buildPipelines == False) or (acceptancePipelines == False):
 		return False
@@ -210,7 +209,7 @@ def afterPipelines(ctx):
 		notify()
 	]
 
-def codestyle():
+def codestyle(ctx):
 	pipelines = []
 
 	if 'codestyle' not in config:
@@ -252,7 +251,7 @@ def codestyle():
 				'name': name,
 				'workspace' : {
 					'base': '/var/www/owncloud',
-					'path': 'server/apps/%s' % config['app']
+					'path': 'server/apps/%s' % ctx.repo.name
 				},
 				'steps': [
 					{
@@ -280,7 +279,7 @@ def codestyle():
 
 	return pipelines
 
-def jscodestyle():
+def jscodestyle(ctx):
 	pipelines = []
 
 	if 'jscodestyle' not in config:
@@ -296,7 +295,7 @@ def jscodestyle():
 		'name': 'coding-standard-js',
 		'workspace' : {
 			'base': '/var/www/owncloud',
-			'path': 'server/apps/%s' % config['app']
+			'path': 'server/apps/%s' % ctx.repo.name
 		},
 		'steps': [
 			{
@@ -324,7 +323,7 @@ def jscodestyle():
 
 	return pipelines
 
-def phpstan():
+def phpstan(ctx):
 	pipelines = []
 
 	if 'phpstan' not in config:
@@ -368,13 +367,13 @@ def phpstan():
 				'name': name,
 				'workspace' : {
 					'base': '/var/www/owncloud',
-					'path': 'server/apps/%s' % config['app']
+					'path': 'server/apps/%s' % ctx.repo.name
 				},
 				'steps':
-					installCore('daily-master-qa', 'sqlite', False) +
-					installApp(phpVersion) +
+					installCore(ctx, 'daily-master-qa', 'sqlite', False) +
+					installApp(ctx, phpVersion) +
 					installExtraApps(phpVersion, params['extraApps']) +
-					setupServerAndApp(phpVersion, params['logLevel']) +
+					setupServerAndApp(ctx, phpVersion, params['logLevel']) +
 				[
 					{
 						'name': 'phpstan',
@@ -401,7 +400,7 @@ def phpstan():
 
 	return pipelines
 
-def phan():
+def phan(ctx):
 	pipelines = []
 
 	if 'phan' not in config:
@@ -443,10 +442,10 @@ def phan():
 				'name': name,
 				'workspace' : {
 					'base': '/var/www/owncloud',
-					'path': 'server/apps/%s' % config['app']
+					'path': 'server/apps/%s' % ctx.repo.name
 				},
 				'steps':
-					installCore('daily-master-qa', 'sqlite', False) +
+					installCore(ctx, 'daily-master-qa', 'sqlite', False) +
 				[
 					{
 						'name': 'phan',
@@ -473,7 +472,7 @@ def phan():
 
 	return pipelines
 
-def build():
+def build(ctx):
 	pipelines = []
 
 	if 'build' not in config:
@@ -513,7 +512,7 @@ def build():
 			'name': 'build',
 			'workspace' : {
 				'base': '/var/www/owncloud',
-				'path': 'server/apps/%s' % config['app']
+				'path': 'server/apps/%s' % ctx.repo.name
 			},
 			'steps': [
 				{
@@ -531,7 +530,7 @@ def build():
 					'settings': {
 						'checksum': 'sha256',
 						'file_exists': 'overwrite',
-						'files': 'build/dist/%s.tar.gz' % config['app'],
+						'files': 'build/dist/%s.tar.gz' % ctx.repo.name,
 						'prerelease': True,
 					},
 					'environment': {
@@ -614,12 +613,12 @@ def javascript(ctx, withCoverage):
 		'name': 'javascript-tests',
 		'workspace' : {
 			'base': '/var/www/owncloud',
-			'path': 'server/apps/%s' % config['app']
+			'path': 'server/apps/%s' % ctx.repo.name
 		},
 		'steps':
-			installCore('daily-master-qa', 'sqlite', False) +
-			installApp('7.4') +
-			setupServerAndApp('7.4', params['logLevel']) +
+			installCore(ctx, 'daily-master-qa', 'sqlite', False) +
+			installApp(ctx, '7.4') +
+			setupServerAndApp(ctx, '7.4', params['logLevel']) +
 			params['extraSetup'] +
 		[
 			{
@@ -747,7 +746,7 @@ def phpTests(ctx, testType, withCoverage):
 			scalityS3Needed = True
 			filesPrimaryS3NeededForScality = scalityS3Params['filesPrimaryS3Needed'] if 'filesPrimaryS3Needed' in scalityS3Params else True
 
-		if ((config['app'] != 'files_primary_s3') and (filesPrimaryS3NeededForCeph or filesPrimaryS3NeededForScality)):
+		if ((ctx.repo.name != 'files_primary_s3') and (filesPrimaryS3NeededForCeph or filesPrimaryS3NeededForScality)):
 			# If we are not already 'files_primary_s3' and we need S3 storage, then install the 'files_primary_s3' app
 			extraAppsDict = {
 				'files_primary_s3': 'composer install'
@@ -784,13 +783,13 @@ def phpTests(ctx, testType, withCoverage):
 					'name': name,
 					'workspace' : {
 						'base': '/var/www/owncloud',
-						'path': 'server/apps/%s' % config['app']
+						'path': 'server/apps/%s' % ctx.repo.name
 					},
 					'steps':
-						installCore('daily-master-qa', db, False) +
-						installApp(phpVersion) +
+						installCore(ctx, 'daily-master-qa', db, False) +
+						installApp(ctx, phpVersion) +
 						installExtraApps(phpVersion, params['extraApps']) +
-						setupServerAndApp(phpVersion, params['logLevel']) +
+						setupServerAndApp(ctx, phpVersion, params['logLevel']) +
 						setupCeph(params['cephS3']) +
 						setupScality(params['scalityS3']) +
 						params['extraSetup'] +
@@ -957,7 +956,7 @@ def acceptance(ctx):
 				scalityS3Needed = True
 				filesPrimaryS3NeededForScality = scalityS3Params['filesPrimaryS3Needed'] if 'filesPrimaryS3Needed' in scalityS3Params else True
 
-			if ((config['app'] != 'files_primary_s3') and (filesPrimaryS3NeededForCeph or filesPrimaryS3NeededForScality)):
+			if ((ctx.repo.name != 'files_primary_s3') and (filesPrimaryS3NeededForCeph or filesPrimaryS3NeededForScality)):
 				# If we are not already 'files_primary_s3' and we need S3 object storage, then install the 'files_primary_s3' app
 				extraAppsDict = {
 					'files_primary_s3': 'composer install'
@@ -1039,15 +1038,15 @@ def acceptance(ctx):
 					'name': name,
 					'workspace' : {
 						'base': '/var/www/owncloud',
-						'path': 'testrunner/apps/%s' % config['app']
+						'path': 'testrunner/apps/%s' % ctx.repo.name
 					},
 					'steps':
-						installCore(testConfig['server'], testConfig['database'], testConfig['useBundledApp']) +
-						installTestrunner('7.4', testConfig['useBundledApp']) +
+						installCore(ctx, testConfig['server'], testConfig['database'], testConfig['useBundledApp']) +
+						installTestrunner(ctx, '7.4', testConfig['useBundledApp']) +
 						(installFederated(testConfig['server'], testConfig['phpVersion'], testConfig['logLevel'], testConfig['database'], federationDbSuffix) + owncloudLog('federated') if testConfig['federatedServerNeeded'] else []) +
-						installApp(testConfig['phpVersion']) +
+						installApp(ctx, testConfig['phpVersion']) +
 						installExtraApps(testConfig['phpVersion'], testConfig['extraApps']) +
-						setupServerAndApp(testConfig['phpVersion'], testConfig['logLevel']) +
+						setupServerAndApp(ctx, testConfig['phpVersion'], testConfig['logLevel']) +
 						owncloudLog('server') +
 						setupCeph(testConfig['cephS3']) +
 						setupScality(testConfig['scalityS3']) +
@@ -1126,7 +1125,7 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 		'name': 'sonar-analysis',
 		'workspace' : {
 			'base': '/var/www/owncloud',
-			'path': 'server/apps/%s' % config['app']
+			'path': 'server/apps/%s' % ctx.repo.name
 		},
 		'clone': {
 			'disable': True, # Sonarcloud does not apply issues on already merged branch
@@ -1143,7 +1142,7 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 		] +
 			cacheRestore() +
 			composerInstall(phpVersion) +
-			installCore('daily-master-qa', 'sqlite', False) +
+			installCore(ctx, 'daily-master-qa', 'sqlite', False) +
 		[
 			{
 				'name': 'sync-from-cache',
@@ -1502,7 +1501,7 @@ def composerInstall(phpVersion):
 		]
 	}]
 
-def installCore(version, db, useBundledApp):
+def installCore(ctx, version, db, useBundledApp):
 	host = getDbName(db)
 	dbType = host
 
@@ -1535,11 +1534,11 @@ def installCore(version, db, useBundledApp):
 	}
 
 	if not useBundledApp:
-		stepDefinition['settings']['exclude'] = 'apps/%s' % config['app']
+		stepDefinition['settings']['exclude'] = 'apps/%s' % ctx.repo.name
 
 	return [stepDefinition]
 
-def installTestrunner(phpVersion, useBundledApp):
+def installTestrunner(ctx, phpVersion, useBundledApp):
 	return [{
 		'name': 'install-testrunner',
 		'image': 'owncloudci/php:%s' % phpVersion,
@@ -1549,7 +1548,7 @@ def installTestrunner(phpVersion, useBundledApp):
 			'git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner',
 			'rsync -aIX /tmp/testrunner /var/www/owncloud',
 		] + ([
-			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
+			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % ctx.repo.name
 		] if not useBundledApp else [])
 	}]
 
@@ -1576,29 +1575,29 @@ def installExtraApps(phpVersion, extraApps):
 		'commands': commandArray
 	}]
 
-def installApp(phpVersion):
+def installApp(ctx, phpVersion):
 	if 'appInstallCommand' not in config:
 		return []
 
 	return [{
-		'name': 'install-app-%s' % config['app'],
+		'name': 'install-app-%s' % ctx.repo.name,
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'cd /var/www/owncloud/server/apps/%s' % config['app'],
+			'cd /var/www/owncloud/server/apps/%s' % ctx.repo.name,
 			config['appInstallCommand']
 		]
 	}]
 
-def setupServerAndApp(phpVersion, logLevel):
+def setupServerAndApp(ctx, phpVersion, logLevel):
 	return [{
-		'name': 'setup-server-%s' % config['app'],
+		'name': 'setup-server-%s' % ctx.repo.name,
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
 			'cd /var/www/owncloud/server',
 			'php occ a:l',
-			'php occ a:e %s' % config['app'],
+			'php occ a:e %s' % ctx.repo.name,
 			'php occ a:e testing',
 			'php occ a:l',
 			'php occ config:system:set trusted_domains 1 --value=server',


### PR DESCRIPTION
Issue https://github.com/owncloud/QA/issues/678

1st commit) Adjust sonar-analysis step so that it overrides the default "clone" step of drone, like core PR https://github.com/owncloud/core/pull/38842

2nd commit) refactor so that we do not need `config['app']` - we can use `ctx.repo.name` to get the current name of the "app".