### PR TITLE
Save relative links in db

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -616,7 +616,7 @@ class FilesHooks {
 
 		$selfAction = $user === $this->currentUser;
 		$app = $type === Files_Sharing::TYPE_SHARED ? 'files_sharing' : 'files';
-		$link = $this->urlGenerator->linkToRouteAbsolute('files.view.index', [
+		$link = $this->urlGenerator->linkToRoute('files.view.index', [
 			'dir' => ($isFile) ? \dirname($path) : $path,
 		]);
 

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -262,6 +262,8 @@ class MailQueueHandler {
 				$l
 			);
 
+			$a  = $this->dataHelper->getParameters($event, 'subject', $activity['amq_subjectparams']);
+
 			$message = $this->dataHelper->translation(
 				$activity['amq_appid'],
 				$activity['amq_subject'],


### PR DESCRIPTION
Before this PR links in the oc_activity table was saved as absolute links, to be consistent with https://github.com/owncloud/core/pull/38639 we save as relative urls, tough this seems to don't have any impact on UI or Emails, because the formatter already handles urls correct 