### PR TITLE
[tests-only] Write comments.file to the correct dir

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,3 +1,10 @@
+dir = {
+    "base": "/var/www/owncloud",
+    "federated": "/var/www/owncloud/federated",
+    "server": "/var/www/owncloud/server",
+    "testrunner": "/var/www/owncloud/testrunner",
+}
+
 config = {
 	'rocketchat': {
 		'channel': 'builds',
@@ -251,7 +258,7 @@ def codestyle(ctx):
 				'type': 'docker',
 				'name': name,
 				'workspace' : {
-					'base': '/var/www/owncloud',
+					'base': dir["base"],
 					'path': 'server/apps/%s' % ctx.repo.name
 				},
 				'steps': [
@@ -295,7 +302,7 @@ def jscodestyle(ctx):
 		'type': 'docker',
 		'name': 'coding-standard-js',
 		'workspace' : {
-			'base': '/var/www/owncloud',
+			'base': dir["base"],
 			'path': 'server/apps/%s' % ctx.repo.name
 		},
 		'steps': [
@@ -367,7 +374,7 @@ def phpstan(ctx):
 				'type': 'docker',
 				'name': name,
 				'workspace' : {
-					'base': '/var/www/owncloud',
+					'base': dir["base"],
 					'path': 'server/apps/%s' % ctx.repo.name
 				},
 				'steps':
@@ -442,7 +449,7 @@ def phan(ctx):
 				'type': 'docker',
 				'name': name,
 				'workspace' : {
-					'base': '/var/www/owncloud',
+					'base': dir["base"],
 					'path': 'server/apps/%s' % ctx.repo.name
 				},
 				'steps':
@@ -512,7 +519,7 @@ def build(ctx):
 			'type': 'docker',
 			'name': 'build',
 			'workspace' : {
-				'base': '/var/www/owncloud',
+				'base': dir["base"],
 				'path': 'server/apps/%s' % ctx.repo.name
 			},
 			'steps': [
@@ -613,7 +620,7 @@ def javascript(ctx, withCoverage):
 		'type': 'docker',
 		'name': 'javascript-tests',
 		'workspace' : {
-			'base': '/var/www/owncloud',
+			'base': dir["base"],
 			'path': 'server/apps/%s' % ctx.repo.name
 		},
 		'steps':
@@ -783,7 +790,7 @@ def phpTests(ctx, testType, withCoverage):
 					'type': 'docker',
 					'name': name,
 					'workspace' : {
-						'base': '/var/www/owncloud',
+						'base': dir["base"],
 						'path': 'server/apps/%s' % ctx.repo.name
 					},
 					'steps':
@@ -1047,7 +1054,7 @@ def acceptance(ctx):
 					'type': 'docker',
 					'name': name,
 					'workspace' : {
-						'base': '/var/www/owncloud',
+						'base': dir["base"],
 						'path': 'testrunner/apps/%s' % ctx.repo.name
 					},
 					'steps':
@@ -1070,8 +1077,8 @@ def acceptance(ctx):
 							'pull': 'always',
 							'environment': environment,
 							'commands': testConfig['extraCommandsBeforeTestRun'] + [
-								'touch /var/www/owncloud/saved-settings.sh',
-								'. /var/www/owncloud/saved-settings.sh',
+								'touch %s/saved-settings.sh' % dir["base"],
+								'. %s/saved-settings.sh' % dir["base"],
 								'make %s' % makeParameter
 							]
 						}),
@@ -1085,9 +1092,9 @@ def acceptance(ctx):
 						scalityService(testConfig['scalityS3']) +
 						elasticSearchService(testConfig['esVersion']) +
 						testConfig['extraServices'] +
-						owncloudService(testConfig['server'], testConfig['phpVersion'], 'server', '/var/www/owncloud/server', testConfig['ssl'], testConfig['xForwardedFor']) +
+						owncloudService(testConfig['server'], testConfig['phpVersion'], 'server', dir["server"], testConfig['ssl'], testConfig['xForwardedFor']) +
 						((
-							owncloudService(testConfig['server'], testConfig['phpVersion'], 'federated', '/var/www/owncloud/federated', testConfig['ssl'], testConfig['xForwardedFor']) +
+							owncloudService(testConfig['server'], testConfig['phpVersion'], 'federated', dir["federated"], testConfig['ssl'], testConfig['xForwardedFor']) +
 							databaseServiceForFederation(testConfig['database'], federationDbSuffix)
 						) if testConfig['federatedServerNeeded'] else [] ),
 					'depends_on': [],
@@ -1134,7 +1141,7 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 		'type': 'docker',
 		'name': 'sonar-analysis',
 		'workspace' : {
-			'base': '/var/www/owncloud',
+			'base': dir["base"],
 			'path': 'server/apps/%s' % ctx.repo.name
 		},
 		'clone': {
@@ -1406,14 +1413,14 @@ def cephService(serviceParams):
 		'environment': serviceEnvironment
 	}]
 
-def owncloudService(version, phpVersion, name = 'server', path = '/var/www/owncloud/server', ssl = True, xForwardedFor = False):
+def owncloudService(version, phpVersion, name, path, ssl, xForwardedFor):
 	if ssl:
 		environment = {
 			'APACHE_WEBROOT': path,
 			'APACHE_CONFIG_TEMPLATE': 'ssl',
 			'APACHE_SSL_CERT_CN': 'server',
-			'APACHE_SSL_CERT': '/var/www/owncloud/%s.crt' % name,
-			'APACHE_SSL_KEY': '/var/www/owncloud/%s.key' % name,
+			'APACHE_SSL_CERT': '%s/%s.crt' % (dir["base"], name),
+			'APACHE_SSL_KEY': '%s/%s.key' % (dir["base"], name),
 			'APACHE_LOGGING_PATH': '/dev/null',
 		}
 	else:
@@ -1534,7 +1541,7 @@ def installCore(ctx, version, db, useBundledApp):
 		'pull': 'always',
 		'settings': {
 			'version': version,
-			'core_path': '/var/www/owncloud/server',
+			'core_path': dir["server"],
 			'db_type': dbType,
 			'db_name': database,
 			'db_host': host,
@@ -1556,21 +1563,21 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
 		'commands': [
 			'mkdir /tmp/testrunner',
 			'git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner',
-			'rsync -aIX /tmp/testrunner /var/www/owncloud',
+			'rsync -aIX /tmp/testrunner %s' % dir["base"],
 		] + ([
-			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % ctx.repo.name
+			'cp -r %s/apps/%s %s/apps/' % (dir["testrunner"], ctx.repo.name, dir["server"])
 		] if not useBundledApp else [])
 	}]
 
 def installExtraApps(phpVersion, extraApps):
 	commandArray = []
 	for app, command in extraApps.items():
-		commandArray.append('git clone https://github.com/owncloud/%s.git /var/www/owncloud/testrunner/apps/%s' % (app, app))
-		commandArray.append('cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % app)
+		commandArray.append('git clone https://github.com/owncloud/%s.git %s/apps/%s' % (app, dir["testrunner"], app))
+		commandArray.append('cp -r %s/apps/%s %s/apps/' % (dir["testrunner"], app, dir["server"]))
 		if (command != ''):
-			commandArray.append('cd /var/www/owncloud/server/apps/%s' % app)
+			commandArray.append('cd %s/apps/%s' % (dir["server"], app))
 			commandArray.append(command)
-		commandArray.append('cd /var/www/owncloud/server')
+		commandArray.append('cd %s' % dir["server"])
 		commandArray.append('php occ a:l')
 		commandArray.append('php occ a:e %s' % app)
 		commandArray.append('php occ a:l')
@@ -1594,7 +1601,7 @@ def installApp(ctx, phpVersion):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'cd /var/www/owncloud/server/apps/%s' % ctx.repo.name,
+			'cd %s/apps/%s' % (dir["server"], ctx.repo.name),
 			config['appInstallCommand']
 		]
 	}]
@@ -1605,7 +1612,7 @@ def setupServerAndApp(ctx, phpVersion, logLevel):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'cd /var/www/owncloud/server',
+			'cd %s' % dir["server"],
 			'php occ a:l',
 			'php occ a:e %s' % ctx.repo.name,
 			'php occ a:e testing',
@@ -1626,9 +1633,9 @@ def setupCeph(serviceParams):
 	createFirstBucket = serviceParams['createFirstBucket'] if 'createFirstBucket' in serviceParams else True
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
 		'wait-for-it -t 600 ceph:80',
-		'cd /var/www/owncloud/server/apps/files_primary_s3',
-		'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
-		'cd /var/www/owncloud/server',
+		'cd %s/apps/files_primary_s3' % dir["server"],
+		'cp tests/drone/ceph.config.php %s/config' % dir["server"],
+		'cd %s' % dir["server"],
 	]
 
 	return [{
@@ -1654,9 +1661,9 @@ def setupScality(serviceParams):
 	createExtraBuckets = serviceParams['createExtraBuckets'] if 'createExtraBuckets' in serviceParams else False
 	setupCommands = serviceParams['setupCommands'] if 'setupCommands' in serviceParams else [
 		'wait-for-it -t 600 scality:8000',
-		'cd /var/www/owncloud/server/apps/files_primary_s3',
-		'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
-		'cd /var/www/owncloud/server'
+		'cd %s/apps/files_primary_s3' % dir["server"],
+		'cp tests/drone/%s %s/config' % (configFile, dir["server"]),
+		'cd %s' % dir["server"]
 	]
 
 	return [{
@@ -1679,7 +1686,7 @@ def setupElasticSearch(esVersion):
 		'image': 'owncloudci/php:7.2',
 		'pull': 'always',
 		'commands': [
-			'cd /var/www/owncloud/server',
+			'cd %s' % dir["server"],
 			'php occ config:app:set search_elastic servers --value elasticsearch',
 			'wait-for-it -t 60 elasticsearch:9200',
 			'php occ search:index:reset --force'
@@ -1692,10 +1699,10 @@ def fixPermissions(phpVersion, federatedServerNeeded):
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'chown -R www-data /var/www/owncloud/server',
+			'chown -R www-data %s' % dir["server"],
 			'wait-for-it -t 600 server:80'
 		] + ([
-			'chown -R www-data /var/www/owncloud/federated',
+			'chown -R www-data %s' % dir["federated"],
 			'wait-for-it -t 600 federated:80'
 		] if federatedServerNeeded else [])
 	}]
@@ -1707,7 +1714,7 @@ def owncloudLog(server):
 		'pull': 'always',
 		'detach': True,
 		'commands': [
-			'tail -f /var/www/owncloud/%s/data/owncloud.log' % server
+			'tail -f %s/%s/data/owncloud.log' % (dir["base"], server)
 		]
 	}]
 
@@ -1737,7 +1744,7 @@ def installFederated(federatedServerVersion, phpVersion, logLevel, db, dbSuffix 
 			'pull': 'always',
 			'settings': {
 				'version': federatedServerVersion,
-				'core_path': '/var/www/owncloud/federated',
+				'core_path': dir["federated"],
 				'db_type': 'mysql',
 				'db_name': database,
 				'db_host': host + dbSuffix,
@@ -1750,8 +1757,8 @@ def installFederated(federatedServerVersion, phpVersion, logLevel, db, dbSuffix 
 			'image': 'owncloudci/php:%s' % phpVersion,
 			'pull': 'always',
 			'commands': [
-				'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
-				'cd /var/www/owncloud/federated',
+				'echo "export TEST_SERVER_FED_URL=http://federated" > %s/saved-settings.sh' % dir["base"],
+				'cd %s' % dir["federated"],
 				'php occ a:l',
 				'php occ a:e testing',
 				'php occ a:l',
@@ -1837,7 +1844,7 @@ def buildGithubCommentForBuildStopped(alternateSuiteName, earlyFail):
             "image": "owncloud/ubuntu:16.04",
             "pull": "always",
             "commands": [
-                'echo ":boom: Acceptance tests pipeline <strong>%s</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> /var/www/owncloud/comments.file' % alternateSuiteName,
+                'echo ":boom: Acceptance tests pipeline <strong>%s</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> %s/comments.file' % (alternateSuiteName, dir["base"]),
             ],
             "when": {
                  "status": [
@@ -1859,7 +1866,7 @@ def githubComment(earlyFail):
             "image": "jmccann/drone-github-comment:1",
             "pull": "if-not-exists",
             "settings": {
-                "message_file": "/var/www/owncloud/comments.file",
+                "message_file": "%s/comments.file" % dir["base"],
             },
             "environment": {
                 "GITHUB_TOKEN": {

--- a/.drone.star
+++ b/.drone.star
@@ -134,6 +134,7 @@ config = {
 }
 
 def main(ctx):
+
 	before = beforePipelines(ctx)
 
 	coverageTests = coveragePipelines(ctx)
@@ -1836,7 +1837,7 @@ def buildGithubCommentForBuildStopped(alternateSuiteName, earlyFail):
             "image": "owncloud/ubuntu:16.04",
             "pull": "always",
             "commands": [
-                'echo ":boom: Acceptance tests pipeline <strong>%s</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> /drone/src/comments.file' % alternateSuiteName,
+                'echo ":boom: Acceptance tests pipeline <strong>%s</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> /var/www/owncloud/comments.file' % alternateSuiteName,
             ],
             "when": {
                  "status": [
@@ -1858,7 +1859,7 @@ def githubComment(earlyFail):
             "image": "jmccann/drone-github-comment:1",
             "pull": "if-not-exists",
             "settings": {
-                "message_file": "/drone/src/comments.file",
+                "message_file": "/var/www/owncloud/comments.file",
             },
             "environment": {
                 "GITHUB_TOKEN": {


### PR DESCRIPTION
1) In oC10 apps the acceptance test pipelines run in `/var/www/owncloud`.
We noticed yesterday, when acceptance tests fail, the comment was not getting posted to GitHub. The starlark that does that was writing to `/drone/src` and that did not work for the oC10 apps.

It was fixed in `files_primary_s3` yesterday.

This PR makes the same change in `activity` app. And it can be propagated from here to the others apps.

2) web PR https://github.com/owncloud/web/pull/5289 removed the repeated hard-coded references to `/var/www/owncloud` through the starlark code. The 2nd commit here does the same. That should reduce the chance for errors in referring to the pipeline directories.