### PR TITLE
[tests-only] Adjust wait-for-it elasticsearch to 600 seconds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1754,7 +1754,7 @@ def setupElasticSearch(esVersion):
 		'commands': [
 			'cd %s' % dir["server"],
 			'php occ config:app:set search_elastic servers --value elasticsearch',
-			'wait-for-it -t 60 elasticsearch:9200',
+			'wait-for-it -t 600 elasticsearch:9200',
 			'php occ search:index:reset --force'
 		]
 	}]


### PR DESCRIPTION
In PR https://github.com/owncloud/files_antivirus/pull/454 I noticed that the `wait-for-it` for `elasticsearch` to start was only 60 seconds. We use 600 seconds as the usual maximum wait time for all other services to start up - that allows for days when "docker pull" is very slow.

Adjust the timeout here. Then it will get propagated to the other oC10 apps when we next copy the "standard starlark code".