### PR TITLE
[tests-only] Fix installApp in .drone.star

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1715,7 +1715,7 @@ def installApp(ctx, phpVersion):
     else:
         installJsDeps = config["buildJsDeps"]
 
-    return [
+    return ([
         {
             "name": "install-app-js-%s" % config["app"],
             "image": "owncloudci/nodejs:%s" % getNodeJsVersion(),
@@ -1726,7 +1726,7 @@ def installApp(ctx, phpVersion):
                 "make build-dev",
             ],
         },
-    ] if installJsDeps else [] + [{
+    ] if installJsDeps else []) + [{
         "name": "install-app-%s" % ctx.repo.name,
         "image": "owncloudci/php:%s" % phpVersion,
         "pull": "always",


### PR DESCRIPTION
The `installApp` function could not return both the `install-app-js-*` and `install-app-*` steps.
I noticed this in https://github.com/owncloud/files_classifier/pull/524/commits/eac2c7f32920dbcc82450aa2e211a0f7ad65a6f8

Fix it with brackets to enclose the logic for the `install-app-js-*` step.