### PR TITLE
[tests-only] wait for selenium browser to start in acceptance tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -301,7 +301,7 @@ def jscodestyle(ctx):
         "steps": [
             {
                 "name": "coding-standard-js",
-                "image": "owncloudci/php:8.0",
+                "image": "owncloudci/nodejs:14",
                 "pull": "always",
                 "commands": [
                     "make test-js-style",


### PR DESCRIPTION
Sometimes the selenium browser service is slow to start, and webUI acceptance tests start running too early:
https://drone.owncloud.com/owncloud/brute_force_protection/1639/14/10
```
Could not open connection: Could not resolve host: selenium (Behat\Mink\Exception\DriverException)
```

We fixed this in core with PR https://github.com/owncloud/core/pull/39323

Do the same here in activity app.

This code can be applied to all the oC10 app repos when we next have a few changes to do.