### PR TITLE
[tests-only] [full-ci] Scroll Activity settings checkbox into view before clicking

### DIFF
--- a/tests/acceptance/features/lib/ActivitySettingForm.php
+++ b/tests/acceptance/features/lib/ActivitySettingForm.php
@@ -55,9 +55,10 @@ class ActivitySettingForm extends OwncloudPage {
 			$activityType,
 			$streamOrMailNumber
 		);
+		$checkboxId = $activityType . "_" . $streamOrMail;
 		$checkCheckboxFullId = \sprintf(
 			$this->activityCheckboxId,
-			$activityType . "_" . $streamOrMail
+			$checkboxId
 		);
 		$checkCheckbox = $this->find("xpath", $checkCheckboxFullId);
 		$activityCheckbox = $this->find("xpath", $checkboxFullXpath);
@@ -75,10 +76,12 @@ class ActivitySettingForm extends OwncloudPage {
 		);
 		if ($disablesOrEnables === 'enables') {
 			if (!$checkCheckbox->isChecked()) {
+				$this->scrollDownAppContent($checkboxId, $session);
 				$activityCheckbox->click();
 			}
 		} elseif ($disablesOrEnables === 'disables') {
 			if ($checkCheckbox->isChecked()) {
+				$this->scrollDownAppContent($checkboxId, $session);
 				$activityCheckbox->click();
 			}
 		} else {
@@ -87,5 +90,27 @@ class ActivitySettingForm extends OwncloudPage {
 			);
 		}
 		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * scrolls down the content of the general settings page to make the
+	 * requested id visible. The div with the scrollbar has id app-content.
+	 *
+	 * Note: there is a similar function in core acceptance tests FilesPageBasic.php
+	 *
+	 * @param string $idToScrollIntoView
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function scrollDownAppContent(
+		string $idToScrollIntoView,
+		Session $session
+	): void {
+		$this->scrollToPosition(
+			"#app-content",
+			'$("#' . $idToScrollIntoView . '").position().top',
+			$session
+		);
 	}
 }


### PR DESCRIPTION
Fixes #1020 

The checkbox for enable/disable of Activity logs for "A file or folder has been shared" was just off the bottom of the visible section of the Personal General Settings page. Something recently must have recently got bigger by a few pixels.

This PR adds code to first scroll the checkbox into view, and then click it. I tested running locally with Firefox and the test failed before the change, and now passes.

The Personal General Settings page has a single scrollbar that is part of the app-content div. That scrolls the whole div which has Profile Picture, Language, Mail Notifications, Activity, and other part in it. The overall length of that div (and thus its scrollbar...) can vary depending on exactly which apps are enabled with which settings. So it is good to explicitly scroll elements into view.