### PR TITLE
[tests-only] Use owncloudci/wait-for docker image

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -222,7 +222,7 @@ def codestyle(ctx):
         return pipelines
 
     default = {
-        "phpVersions": ["7.3"],
+        "phpVersions": ["7.4"],
     }
 
     if "defaults" in config:
@@ -387,7 +387,7 @@ def phpstan(ctx):
         return pipelines
 
     default = {
-        "phpVersions": ["7.3"],
+        "phpVersions": ["7.4"],
         "logLevel": "2",
         "extraApps": {},
         "enableApp": True,
@@ -464,7 +464,7 @@ def phan(ctx):
         return pipelines
 
     default = {
-        "phpVersions": ["7.3", "7.4"],
+        "phpVersions": ["7.4"],
     }
 
     if "defaults" in config:


### PR DESCRIPTION
Use the `owncloudci/wait-for` docker image in drone CI (like is done in web, oCIS  etc)

Add `waitForEmailService` to wait for the mailhog docker image to pull and start.

Add `waitForServer` to wait for the Apache server to start.

Refactor with constants for the docker image names, like has been done in other repos.

This is similar functionality to core PR https://github.com/owncloud/core/pull/39562

Part of issue https://github.com/owncloud/core/issues/39561