### PR TITLE
Use core acceptance-test-changes-waiting-2021-11 branch for acceptance tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1708,7 +1708,7 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         "pull": "always",
         "commands": [
             "mkdir /tmp/testrunner",
-            "git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner",
+            "git clone -b acceptance-test-changes-waiting-2021-11 --depth=1 https://github.com/owncloud/core.git /tmp/testrunner",
             "rsync -aIX /tmp/testrunner %s" % dir["base"],
         ] + ([
             "cp -r %s/apps/%s %s/apps/" % (dir["testrunner"], ctx.repo.name, dir["server"]),


### PR DESCRIPTION
This should be the fix for issue #1037 

A test change was made in core PR https://github.com/owncloud/core/pull/39514 and that code is currently in core branch `acceptance-test-changes-waiting-2021-11`

So use that code for now.