### PR TITLE
[tests-only] Test against core master

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1727,7 +1727,7 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         "pull": "always",
         "commands": [
             "mkdir /tmp/testrunner",
-            "git clone -b acceptance-test-changes-waiting-2021-11 --depth=1 https://github.com/owncloud/core.git /tmp/testrunner",
+            "git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner",
             "rsync -aIX /tmp/testrunner %s" % dir["base"],
         ] + ([
             "cp -r %s/apps/%s %s/apps/" % (dir["testrunner"], ctx.repo.name, dir["server"]),


### PR DESCRIPTION
PR #1038 started testing against core branch `acceptance-test-changes-waiting-2021-11` but actually that does not work, because there are core changes in that branch that are incompatible with the core tarballs. Nightly CI is failing because of some new/changed tests for new group name behavior that are not yet in core master.

Revert that change.