### PR TITLE
[tests-only] [full-ci] Use PHP 7.4 in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -20,23 +20,7 @@ config = {
     ],
     "codestyle": True,
     "javascript": True,
-    "phpunit": {
-        "allDatabases": {
-            "phpVersions": [
-                "7.3",
-            ],
-        },
-        "reducedDatabases": {
-            "phpVersions": [
-                "7.4",
-            ],
-            "databases": [
-                "sqlite",
-                "mariadb:10.2",
-            ],
-            "coverage": False,
-        },
-    },
+    "phpunit": True,
     "acceptance": {
         "webUI": {
             "suites": {
@@ -535,7 +519,7 @@ def build(ctx):
         return pipelines
 
     default = {
-        "phpVersions": ["7.3"],
+        "phpVersions": ["7.4"],
         "commands": [
             "make dist",
         ],
@@ -734,7 +718,7 @@ def phpTests(ctx, testType, withCoverage):
     errorFound = False
 
     default = {
-        "phpVersions": ["7.3", "7.4"],
+        "phpVersions": ["7.4"],
         "databases": [
             "sqlite",
             "mariadb:10.2",


### PR DESCRIPTION
Change a couple more places to use PHP 7.4 in CI by default.
If there are any apps where we want to still use PHP 7.3 for some pipeline, then it is easy to put that in the `config[]` section.