### PR TITLE
Add composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
   "config" : {
     "platform": {
       "php": "7.3"
+    },
+    "allow-plugins": {
+      "bamarni/composer-bin-plugin": true
     }
   },
   "require": {


### PR DESCRIPTION
I updated my local system to the latest `composer` 2.2.6. When I do `composer update` it now asks me if I trust the composer plugins that we use. After answering "yes" it adds that "trust" to `composer.json`

https://getcomposer.org/doc/06-config.md#allow-plugins
"As of Composer 2.2.0, the allow-plugins option adds a layer of security allowing you to restrict which Composer plugins are able to execute code during a Composer run."

This PR commits the `allow-plugins` section for `composer.json` so that it is there for anyone who updates to composer 2.2

This is a tool change, no changelog is required.
