### PR TITLE
[tests-only] Start federated server for core-cli test pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -93,6 +93,7 @@ config = {
                 "7.4",
             ],
             "runCoreTests": True,
+            "federatedServerNeeded": True,
             "cron": "nightly",
             "runAllSuites": True,
             "numberOfParts": 3,


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/39799

PR #1067 runs the pipelines in the PR, to demonstrate that CI will pass.

In this PR #1066 those pipelines do not run - they normally only run in nightly CI.