### PR TITLE
[tests-only] Do not run PHP unit tests with Oracle by default

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -718,7 +718,33 @@ def phpTests(ctx, testType, withCoverage):
 
     errorFound = False
 
-    default = {
+    # The default PHP unit test settings for a PR.
+    # Note: do not run Oracle by default in PRs.
+    prDefault = {
+        "phpVersions": ["7.4"],
+        "databases": [
+            "sqlite",
+            "mariadb:10.2",
+            "mysql:8.0",
+            "postgres:9.4",
+        ],
+        "coverage": True,
+        "includeKeyInMatrixName": False,
+        "logLevel": "2",
+        "cephS3": False,
+        "scalityS3": False,
+        "extraSetup": [],
+        "extraServices": [],
+        "extraEnvironment": {},
+        "extraCommandsBeforeTestRun": [],
+        "extraApps": {},
+        "extraTeardown": [],
+        "skip": False,
+        "enableApp": True,
+    }
+
+    # The default PHP unit test settings for the cron job (usually runs nightly).
+    cronDefault = {
         "phpVersions": ["7.4"],
         "databases": [
             "sqlite",
@@ -741,6 +767,11 @@ def phpTests(ctx, testType, withCoverage):
         "skip": False,
         "enableApp": True,
     }
+
+    if (ctx.build.event == "cron"):
+        default = cronDefault
+    else:
+        default = prDefault
 
     if "defaults" in config:
         if testType in config["defaults"]:


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/38679

Do not run PHP unit tests with Oracle in PRs. Only do that in the nightly CI.

https://drone.owncloud.com/owncloud/activity/2513 - there are PHP unit CI pipelines for sqlite, mariadb, mysql, and postgresql. There is no pipeline for Oracle - correct.

This is the example change to `.drone.star`. After approval and merge here, the similar update needs to be dome in all other oC10 app repos. There is no big hurry for that.