### PR TITLE
Discard activity emails for users with invalid email addresses

### DIFF
--- a/lib/BackgroundJob/EmailNotification.php
+++ b/lib/BackgroundJob/EmailNotification.php
@@ -137,6 +137,14 @@ class EmailNotification extends TimedJob {
 				continue;
 			}
 
+			if (!$this->mqHandler->validateMailAddress($user['email'])) {
+				// The user's email address does not pass validation
+				// So we will not send an email but still discard the queued entries
+				$this->logger->debug("Couldn't send notification email to user '$uid' (invalid email address set for that user)", ['app' => 'activity']);
+				$sentMailForUsers[] = $uid;
+				continue;
+			}
+
 			$language = (!empty($userLanguages[$uid])) ? $userLanguages[$uid] : $default_lang;
 			$timezone = (!empty($userTimezones[$uid])) ? $userTimezones[$uid] : $defaultTimeZone;
 

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -211,6 +211,16 @@ class MailQueueHandler {
 	}
 
 	/**
+	 * Validate an email addresss
+	 *
+	 * @param string $email Email address to be validated
+	 * @return bool
+	 */
+	public function validateMailAddress($email) {
+		return $this->mailer->validateMailAddress($email);
+	}
+
+	/**
 	 * Send a notification to one user
 	 *
 	 * @param string $userName Username of the recipient

--- a/tests/Unit/BackgroundJob/EmailNotificationTest.php
+++ b/tests/Unit/BackgroundJob/EmailNotificationTest.php
@@ -98,12 +98,12 @@ class EmailNotificationTest extends TestCase {
 			->method('getAffectedUsers')
 			->with(2, 200)
 			->willReturn([
-				['uid' => 'test1', 'email' => 'test1@localhost'],
+				['uid' => 'test1', 'email' => 'foo@owncloud.com'],
 				['uid' => 'test2', 'email' => ''],
 			]);
 		$this->mqHandler->expects($this->once())
 			->method('sendEmailToUser')
-			->with('test1', 'test1@localhost', 'de', \date_default_timezone_get(), $this->anything());
+			->with('test1', 'foo@owncloud.com', 'de', \date_default_timezone_get(), $this->anything());
 		$this->config->expects($this->any())
 			->method('getUserValueForUsers')
 			->willReturnMap([


### PR DESCRIPTION
This adds email address validation to the background job for the event a user has been able to set an invalid email address on their account.

It will discard the email queue for the user if they have an invalid email address to avoid a backlog of items being queued up.