### PR TITLE
[tests-only] [full-ci] Adjust installExtraApps to be more flexible about app install

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1727,8 +1727,8 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
 def installExtraApps(phpVersion, extraApps):
     commandArray = []
     for app, command in extraApps.items():
-        commandArray.append("git clone https://github.com/owncloud/%s.git %s/apps/%s" % (app, dir["testrunner"], app))
-        commandArray.append("cp -r %s/apps/%s %s/apps/" % (dir["testrunner"], app, dir["server"]))
+        commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (dir["testrunner"], app, app, dir["testrunner"], app))
+        commandArray.append("ls %s/apps/%s || cp -r %s/apps/%s %s/apps/" % (dir["server"], app, dir["testrunner"], app, dir["server"]))
         if (command != ""):
             commandArray.append("cd %s/apps/%s" % (dir["server"], app))
             commandArray.append(command)


### PR DESCRIPTION
We can specify `extraApps` in the config of various test sections in `.drone.star`. Nowadays `files_external` is a built-in core app that is disabled by default. We want to enable it, but we don't need to clone it.

Make the code more flexible so that it does not `git clone` the app if the app code already exists. The code is taken from the way this is already done in `ownclud/core`

This change was first made in search_elastic PR https://github.com/owncloud/search_elastic/pull/266 and works.

This PR applies the change to the activity app. It can be copied from here to other apps.