### PR TITLE
[tests-only] enable files_external app when running core tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -103,6 +103,9 @@ config = {
             "runAllSuites": True,
             "numberOfParts": 35,
             "filterTags": "~@skip&&~@app-required",
+            "extraApps": {
+                "files_external": "",
+            },
         },
         "core-cli-acceptance": {
             "suites": {
@@ -124,6 +127,9 @@ config = {
             "numberOfParts": 3,
             "emailNeeded": True,
             "filterTags": "~@skip&&~@app-required&&~@dbConversion",
+            "extraApps": {
+                "files_external": "",
+            },
         },
         "core-webui-acceptance": {
             "suites": {
@@ -145,6 +151,9 @@ config = {
             "runAllSuites": True,
             "numberOfParts": 5,
             "filterTags": "@smokeTest&&~@skip&&~@app-required",
+            "extraApps": {
+                "files_external": "",
+            },
         },
     },
 }


### PR DESCRIPTION
because some core tests are testing with local_storage and that requires the files_external app to be enabled.