### PR TITLE
[tests-only] Enable files_external app in federated server

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1987,6 +1987,7 @@ def installFederated(federatedServerVersion, phpVersion, logLevel, db, dbSuffix 
                 "echo 'export TEST_SERVER_FED_URL=http://federated' > %s/saved-settings.sh" % dir["base"],
                 "cd %s" % dir["federated"],
                 "php occ a:l",
+                "php occ a:e files_external",
                 "php occ a:e testing",
                 "php occ a:l",
                 "php occ config:system:set trusted_domains 1 --value=federated",


### PR DESCRIPTION
Nothing is failing in the activity app CI. But it will be easiest in future if we make sure that the federated server in CI has the files_external app enabled. files_external app was recently disabled by default in core.

This small change to the drone CI can get copied to other apps whenever we have a need to copy.