### PR TITLE
[tests-only] [full-ci] Refactored steps, added  missing word

### DIFF
--- a/tests/acceptance/features/apiActivity/list.feature
+++ b/tests/acceptance/features/apiActivity/list.feature
@@ -807,7 +807,7 @@ Feature: List activity
     When user "Alice" has created a public link share with settings
       | path       | /lorem.txt |
       | expireDate | +15 days   |
-    And the administrator expires the last created share using the testing API
+    And the administrator expires the last created public link share using the testing API
     # Testing api is used above so to tigger the latest list of activity
     And user "Alice" gets all shares shared by him using the sharing API
     Then the activity number 1 of user "Alice" should match these properties:
@@ -828,7 +828,7 @@ Feature: List activity
       | object_name      | /^\/lorem.txt$/                                                                                                                           |
       | object_type      | /^files$/                                                                                                                                 |
       | subject_prepared | /^You shared <file link=\"%base_url%\/(index\.php\/)?apps\/files\/\?dir=\/&scrollto=lorem\.txt\" id=\"\d+\">lorem\.txt<\/file> via link$/ |
-    And the last share id should not be included in the response
+    And the last public link share id should not be included in the response
 
 
   Scenario: check activity after renaming a shared folder
@@ -1173,7 +1173,7 @@ Feature: List activity
     And user "Alice" has created a public link share with settings
       | path        | /parent                   |
       | permissions | read,update,create,delete |
-    When the public renames file "/textfile0.txt" to "textfile.txt" from the last public share using the new public WebDAV API
+    When the public renames file "/textfile0.txt" to "textfile.txt" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/parent/textfile.txt" should exist
     And as user "Alice" the activity number 1 for "/parent/textfile.txt" should match these properties:

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkShare.feature
@@ -25,7 +25,7 @@ Feature: public link sharing file/folders activities
   @issue-690
   Scenario: Downloading a file from a public shared folder using API should be listed in the activity list
     Given user "Brian" has created a public link share of folder "simple-folder"
-    When the public downloads file "lorem.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API
+    When the public downloads file "lorem.txt" from inside the last public link shared folder with range "bytes=1-7" using the old public WebDAV API
     And the user browses to the activity page
     Then the activity number 1 should contain message "You shared simple-folder via link" in the activity page
     #Then the activity number 1 should contain message "Public shared file lorem.txt was downloaded" in the activity page


### PR DESCRIPTION
This PR adds the word `link` to steps to match the step implementation.

- Fixes https://github.com/owncloud/activity/issues/1110