### PR TITLE
[full-ci] [tests-only] Added scenarios to check activity list after share is expired for federated share

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -117,3 +117,4 @@ default:
         - TrashbinContext:
         - PublicWebDavContext:
         - FeatureContext: *common_feature_context_params
+        - FederationContext:


### PR DESCRIPTION
This PR adds a scenario to check the activity list after the share is expired for the federated share.

Part of issue https://github.com/owncloud/activity/issues/968