### PR TITLE
[tests-only] Update vendor-bin tool versions to current minor versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "require": {
   },
   "require-dev": {
-    "bamarni/composer-bin-plugin": "^1.4"
+    "bamarni/composer-bin-plugin": "^1.8"
   },
   "extra": {
     "bamarni-bin": {

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -5,17 +5,17 @@
         }
     },
     "require": {
-        "behat/behat": "^3.9",
+        "behat/behat": "^3.11",
         "behat/gherkin": "^4.9",
         "behat/mink": "1.7.1",
-        "friends-of-behat/mink-extension": "^2.5",
+        "friends-of-behat/mink-extension": "^2.7",
         "behat/mink-selenium2-driver": "^1.5",
         "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.3",
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
-        "guzzlehttp/guzzle": "^7.4",
+        "guzzlehttp/guzzle": "^7.5",
         "phpunit/phpunit": "^9.5"
     }
 }

--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,8 +1,5 @@
 {
     "require": {
-        "squizlabs/php_codesniffer": "^3.5"
-    },
-    "conflict": {
-        "squizlabs/php_codesniffer": "3.5.1"
+        "squizlabs/php_codesniffer": "^3.7"
     }
 }


### PR DESCRIPTION
Similar to core PR https://github.com/owncloud/core/pull/40395

Get these versions up-to-date in the various `composer.json` files so that we are easily aware of what versions are really running in CI etc.