### PR TITLE
[tests-only] [full-ci] Run CI with PHP 7.4-ubuntu20.04

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -25,7 +25,7 @@ SELENIUM_STANDALONE_FIREFOX_DEBUG = "selenium/standalone-firefox-debug:3.8.1"
 SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli"
 THEGEEKLAB_DRONE_GITHUB_COMMENT = "thegeeklab/drone-github-comment:1"
 
-DEFAULT_PHP_VERSION = "7.4"
+DEFAULT_PHP_VERSION = "7.4-ubuntu20.04"
 DEFAULT_NODEJS_VERSION = "14"
 
 dir = {


### PR DESCRIPTION
This is a test to see if it passes. We can decide next week if we explicitly change to `owncloudci/php:7.4-ubuntu20.04` or if we update `owncloudci/php:7.4` so that it uses Ubuntu 20.04 (instead of Ubuntu 18.04) or if we design some other naming system for tagging the Docker images so that we know which Ubuntu+PHP combinations are being used.