### PR TITLE
Implement owncloud/coding-standard 4

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,11 +1,8 @@
 <?php
+$finder = PhpCsFixer\Finder::create()
+	->notPath('templates/html.notification.php')
+	->in(__DIR__);
 
 $config = new OC\CodingStandard\Config();
-
-$config
-    ->setUsingCache(true)
-    ->getFinder()
-    ->in(__DIR__);
-
+$config->setFinder($finder);
 return $config;
-

--- a/appinfo/Migrations/Version20161122092159.php
+++ b/appinfo/Migrations/Version20161122092159.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Types\Type;
 use OCP\Migration\ISchemaMigration;
 
 class Version20161122092159 implements ISchemaMigration {
-
 	/**
 	 * @param Schema $schema
 	 * @param array $options

--- a/appinfo/Migrations/Version20170724182159.php
+++ b/appinfo/Migrations/Version20170724182159.php
@@ -11,7 +11,6 @@ use OCP\Migration\ISchemaMigration;
  */
 
 class Version20170724182159 implements ISchemaMigration {
-
 	/**
 	 * @param Schema $schema
 	 * @param array $options

--- a/appinfo/Migrations/Version20181022150134.php
+++ b/appinfo/Migrations/Version20181022150134.php
@@ -34,7 +34,6 @@ use OCP\IDBConnection;
  *
  */
 class Version20181022150134 implements ISqlMigration {
-
 	/**
 	 * @param Schema $schema
 	 * @param array $options

--- a/lib/Consumer.php
+++ b/lib/Consumer.php
@@ -28,7 +28,6 @@ use OCP\Activity\IExtension;
 use OCP\L10N\IFactory;
 
 class Consumer implements IConsumer {
-
 	/** @var Data */
 	protected $data;
 

--- a/lib/Controller/Activities.php
+++ b/lib/Controller/Activities.php
@@ -29,7 +29,6 @@ use OCP\IConfig;
 use OCP\IRequest;
 
 class Activities extends Controller {
-
 	/** @var \OCA\Activity\Data */
 	protected $data;
 

--- a/lib/Controller/EndPoint.php
+++ b/lib/Controller/EndPoint.php
@@ -27,7 +27,6 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class EndPoint extends Controller {
-
 	/** @var OCSEndPoint */
 	protected $ocsEndPoint;
 

--- a/lib/Controller/OCSEndPoint.php
+++ b/lib/Controller/OCSEndPoint.php
@@ -37,7 +37,6 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class OCSEndPoint {
-
 	/** @var string */
 	protected $filter;
 

--- a/lib/FilesHooksStatic.php
+++ b/lib/FilesHooksStatic.php
@@ -28,7 +28,6 @@ use OCP\Util;
  * The class to handle the filesystem hooks
  */
 class FilesHooksStatic {
-
 	/**
 	 * @var Appinfo\Application
 	 */

--- a/lib/Formatter/GroupFormatter.php
+++ b/lib/Formatter/GroupFormatter.php
@@ -26,7 +26,6 @@ use OCP\IGroupManager;
 use OCP\Util;
 
 class GroupFormatter implements IFormatter {
-
 	/** @var IGroupManager  */
 	protected $groupManager;
 

--- a/lib/Formatter/UrlFormatter.php
+++ b/lib/Formatter/UrlFormatter.php
@@ -25,7 +25,6 @@ use OCP\Activity\IEvent;
 use OCP\Util;
 
 class UrlFormatter implements IFormatter {
-
 	/**
 	 * Format a list of url parameters into an html a-tag. The parameters have to be provided as json encoded data, i.e. a string.
 	 * Allowed values are:

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -30,7 +30,6 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * Handles the stream and mail queue of a user when he is being deleted
  */
 class Hooks {
-
 	/**
 	 * Delete remaining activities and emails when a user is deleted
 	 *

--- a/lib/HtmlTextParser.php
+++ b/lib/HtmlTextParser.php
@@ -25,7 +25,6 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class HtmlTextParser extends PlainTextParser {
-
 	/**
 	 * @var IURLGenerator
 	 */

--- a/lib/Parameter/IParameter.php
+++ b/lib/Parameter/IParameter.php
@@ -22,7 +22,6 @@
 namespace OCA\Activity\Parameter;
 
 interface IParameter {
-
 	/**
 	 * A value that is used to check, if the parameter is already in a Collection
 	 * @return mixed

--- a/lib/PersonalPanel.php
+++ b/lib/PersonalPanel.php
@@ -5,7 +5,6 @@ namespace OCA\Activity;
 use OCP\Settings\ISettings;
 
 class PersonalPanel implements ISettings {
-
 	/** @var AppInfo\Application  */
 	protected $app;
 

--- a/lib/PlainTextParser.php
+++ b/lib/PlainTextParser.php
@@ -24,7 +24,6 @@ namespace OCA\Activity;
 use OCP\IL10N;
 
 class PlainTextParser {
-
 	/** @var IL10N */
 	protected $l;
 

--- a/lib/ViewInfoCache.php
+++ b/lib/ViewInfoCache.php
@@ -25,7 +25,6 @@ use OC\Files\View;
 use OCP\Files\NotFoundException;
 
 class ViewInfoCache {
-
 	/** @var array */
 	protected $cachePath;
 	/** @var array */

--- a/templates/stream.app.navigation.php
+++ b/templates/stream.app.navigation.php
@@ -8,22 +8,22 @@
 ?>
 <div id="app-navigation">
 	<?php foreach ($_['navigations'] as $navigationGroup => $navigationEntries) {
-	?>
+		?>
 		<?php if ($navigationGroup !== 'apps'): ?><ul><?php endif; ?>
 
 		<?php foreach ($navigationEntries as $navigation) {
-		?>
+			?>
 		<li<?php if ($_['activeNavigation'] === $navigation['id']): ?> class="active"<?php endif; ?>>
 			<a data-navigation="<?php p($navigation['id']) ?>" href="<?php p($navigation['url']) ?>">
 				<?php p($navigation['name']) ?>
 			</a>
 		</li>
 		<?php
-	} ?>
+		} ?>
 
 		<?php if ($navigationGroup !== 'top'): ?></ul><?php endif; ?>
 	<?php
-} ?>
+	} ?>
 
 	<div id="app-settings">
 		<div id="app-settings-header">

--- a/tests/acceptance/features/lib/ActivityPage.php
+++ b/tests/acceptance/features/lib/ActivityPage.php
@@ -35,7 +35,6 @@ use Behat\Mink\Session;
  * activity app gets an overhaul, it might require us to have two separate pages.
  */
 class ActivityPage extends OwncloudPage {
-
 	/**
 	 *
 	 * @var string $path

--- a/tests/unit/Formatter/BaseFormatterTest.php
+++ b/tests/unit/Formatter/BaseFormatterTest.php
@@ -26,7 +26,6 @@ use OCA\Activity\Formatter\BaseFormatter;
 use OCA\Activity\Tests\Unit\TestCase;
 
 class BaseFormatterTest extends TestCase {
-
 	/**
 	 * @param array $methods
 	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject

--- a/tests/unit/Formatter/GroupFormatterTest.php
+++ b/tests/unit/Formatter/GroupFormatterTest.php
@@ -28,7 +28,6 @@ use OCP\IGroup;
 use OCP\IGroupManager;
 
 class GroupFormatterTest extends TestCase {
-
 	/** @var  \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $groupManager;
 

--- a/tests/unit/Formatter/UrlFormatterTest.php
+++ b/tests/unit/Formatter/UrlFormatterTest.php
@@ -27,7 +27,6 @@ use OCA\Activity\Tests\Unit\TestCase;
 use OCP\Activity\IEvent;
 
 class UrlFormatterTest extends TestCase {
-
 	/**
 	 * @param array $methods
 	 * @return IFormatter|\PHPUnit\Framework\MockObject\MockObject

--- a/tests/unit/Formatter/UserFormatterTest.php
+++ b/tests/unit/Formatter/UserFormatterTest.php
@@ -26,7 +26,6 @@ use OCA\Activity\Formatter\UserFormatter;
 use OCA\Activity\Tests\Unit\TestCase;
 
 class UserFormatterTest extends TestCase {
-
 	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 

--- a/tests/unit/MailQueueHandlerTest.php
+++ b/tests/unit/MailQueueHandlerTest.php
@@ -32,7 +32,6 @@ use OCP\IUser;
  * @package OCA\Activity\Tests
  */
 class MailQueueHandlerTest extends TestCase {
-
 	/** @var MailQueueHandler */
 	protected $mailQueueHandler;
 

--- a/tests/unit/Parsers/HtmlTextParserTest.php
+++ b/tests/unit/Parsers/HtmlTextParserTest.php
@@ -8,7 +8,6 @@ use OCP\IURLGenerator;
 use Test\TestCase;
 
 class HtmlTextParserTest extends TestCase {
-
 	/**
 	 * @dataProvider providesMessages
 	 * @param string $expected

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "owncloud/coding-standard": "^3.0"
+        "owncloud/coding-standard": "^4.0"
     }
 }


### PR DESCRIPTION
`owncloud/coding-standard` 4 uses the latest php-cs-fixer release.

That can do some strange indenting in code with mixed HTML and PHP. That happens in some `templates/*.php` files. I have excluded `templates/html.notification.php` so that the indenting does not get changed.

A similar thing was done in core PR https://github.com/owncloud/core/pull/40490

Issue https://github.com/owncloud/QA/issues/779