### PR TITLE
[tests-only] Check PHP code with 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -45,7 +45,14 @@ config = {
     "branches": [
         "master",
     ],
-    "codestyle": True,
+    "codestyle": {
+        "multiple": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "javascript": True,
     "phpunit": True,
     "acceptance": {

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "owncloud/coding-standard": "^4.0"
+        "owncloud/coding-standard": "^3.0|^4.0"
     }
 }


### PR DESCRIPTION
oC10 core up to 10.11 supports PHP 7.3. For the time being, when we release core apps, we want to know that the PHP code works OK with PHP 7.3. So run code-style in CI with PHP 7.3