### PR TITLE
[tests-only] [full-ci] Add wait-for-samba drone CI code

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1239,6 +1239,7 @@ def acceptance(ctx):
                              testConfig["extraSetup"] +
                              waitForServer(testConfig["federatedServerNeeded"]) +
                              waitForEmailService(testConfig["emailNeeded"]) +
+                             waitForSamba(testConfig["extraServices"]) +
                              fixPermissions(phpVersionForDocker, testConfig["federatedServerNeeded"], params["selUserNeeded"]) +
                              waitForBrowserService(testConfig["browser"]) +
                              [
@@ -1534,6 +1535,26 @@ def waitForEmailService(emailNeeded):
             "image": OC_CI_WAIT_FOR,
             "commands": [
                 "wait-for -it email:9000 -t 600",
+            ],
+        }]
+
+    return []
+
+def waitForSamba(extraServices):
+    foundSamba = False
+
+    for extraService in extraServices:
+        # each service entry should be a key-value dictionary that has at least a "name" key
+        # if there is a "samba" service specified, then we need to wait for it to start.
+        if (extraService["name"] == "samba"):
+            foundSamba = True
+
+    if (foundSamba):
+        return [{
+            "name": "wait-for-samba",
+            "image": OC_CI_WAIT_FOR,
+            "commands": [
+                "wait-for -it samba:139,samba:445 -t 300",
             ],
         }]
 


### PR DESCRIPTION
This is the new code from WND PRs https://github.com/owncloud/windows_network_drive/pull/418 and https://github.com/owncloud/windows_network_drive/pull/419

Adding it here in the activity app CI logic so that it will be in the "standard" oC10 app CI code, and will get copied to the other repos next time we need to do a general update of the drone starlark rate.