### PR TITLE
Add drone pipeline to check the oc10 daily tarball build

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2345,17 +2345,13 @@ def validateDailyTarballBuild():
     pipeline = {
         "kind": "pipeline",
         "type": "docker",
-        "name": "validate-daily-tarball-build",
-        "environment": {
-            # provide multiple values separated by comma
-            "DAILY_TARBALLS": "daily-master,daily-master-qa",
-        },
+        "name": "check-tarball-build-date",
         "steps": [{
-            "name": "check-daily-tarball",
+            "name": "check-build-date",
             "image": OC_CI_ALPINE,
             "commands": [
-                "chmod +x ./tests/drone/validate-oc-daily-tarball.sh",
-                "./tests/drone/validate-oc-daily-tarball.sh",
+                "chmod +x ./tests/drone/check-daily-update.sh",
+                "./tests/drone/check-daily-update.sh %s %s" % ("daily-master", "daily-master-qa"),
             ],
         }],
         "depends_on": [],

--- a/tests/drone/check-daily-update.sh
+++ b/tests/drone/check-daily-update.sh
@@ -1,9 +1,12 @@
 #! /bin/bash
 set -e
 
-if [[ -z "${DAILY_TARBALLS}" ]]; then
-    echo "[ERROR] 'DAILY_TARBALLS' is not set"
-    echo "[INFO] Provide 'DAILY_TARBALLS' as env with values separated by comma"
+# Args:
+# 1...n - tarballs to check
+
+if ! [[ $# -gt 0 ]]; then
+    echo "[ERROR] Tarball is not provided"
+    echo "[INFO] Provide tarballs as command args separated by a space"
     exit 1
 fi
 
@@ -11,16 +14,17 @@ DOWNLOAD_URL="https://download.owncloud.com/server/daily"
 DESTINATION="/tmp/owncloud"
 EXIT_CODE=1
 
-IFS=',' read -ra TARBALLS <<<"$DAILY_TARBALLS"
-for TARBALL in "${TARBALLS[@]}"; do
+while [[ $# -gt 0 ]]; do
     # create the destination
     mkdir -p "${DESTINATION}"
 
     # remove white spaces
-    TARBALL=$(echo "${TARBALL}" | tr -d '[:space:]')
-    if [[ "${TARBALL}" != "owncloud-*" ]] && [[ "${TARBALL}" != "*.tar.bz2" ]]; then
+    TARBALL=$(echo "$1" | tr -d '[:space:]')
+
+    if ! [[ "${TARBALL}" =~ ^owncloud-.* ]] && ! [[ "${TARBALL}" =~ .*\.tar\.bz2$ ]]; then
         TARBALL="owncloud-${TARBALL}.tar.bz2"
     fi
+
     echo -e "\n-----------------------------------------------------------------"
     echo "[INFO] Checking tarball '${TARBALL}'"
     echo "[INFO] Downloading '${DOWNLOAD_URL}/${TARBALL}'"
@@ -45,9 +49,10 @@ for TARBALL in "${TARBALLS[@]}"; do
     else
         echo "[ERROR] Daily tarball '${TARBALL}' is not up to date"
         echo "[INFO] Tarball build date: ${BUILD_DATE}"
-        echo "[INFO] Today: ${BUILD_DATE}"
+        echo "[INFO] Today: ${TODAY}"
         EXIT_CODE=1
     fi
+    shift
 done
 
 exit ${EXIT_CODE}

--- a/tests/drone/validate-oc-daily-tarball.sh
+++ b/tests/drone/validate-oc-daily-tarball.sh
@@ -1,0 +1,53 @@
+#! /bin/bash
+set -e
+
+if [[ -z "${DAILY_TARBALLS}" ]]; then
+    echo "[ERROR] 'DAILY_TARBALLS' is not set"
+    echo "[INFO] Provide 'DAILY_TARBALLS' as env with values separated by comma"
+    exit 1
+fi
+
+DOWNLOAD_URL="https://download.owncloud.com/server/daily"
+DESTINATION="/tmp/owncloud"
+EXIT_CODE=1
+
+IFS=',' read -ra TARBALLS <<<"$DAILY_TARBALLS"
+for TARBALL in "${TARBALLS[@]}"; do
+    # create the destination
+    mkdir -p "${DESTINATION}"
+
+    # remove white spaces
+    TARBALL=$(echo "${TARBALL}" | tr -d '[:space:]')
+    if [[ "${TARBALL}" != "owncloud-*" ]] && [[ "${TARBALL}" != "*.tar.bz2" ]]; then
+        TARBALL="owncloud-${TARBALL}.tar.bz2"
+    fi
+    echo -e "\n-----------------------------------------------------------------"
+    echo "[INFO] Checking tarball '${TARBALL}'"
+    echo "[INFO] Downloading '${DOWNLOAD_URL}/${TARBALL}'"
+    echo "[INFO] Extracting tarball to '${DESTINATION}'"
+    # download and extract the tarball
+    wget -qO- "${DOWNLOAD_URL}/${TARBALL}" | tar -xj -C "${DESTINATION}" --strip 1
+
+    BUILD_DATE=$(grep "\$OC_Build =" "${DESTINATION}/version.php")
+    BUILD_DATE=$(echo "${BUILD_DATE}" | grep -Eo "[0-9\-]+" | head -1)
+
+    TODAY=$(date +%Y-%m-%d)
+    # busybox date does not support the following format:
+    #   -d "-1 days"
+    YESTERDAY=$(date -d "@$(($(date +%s) - 86400))" +%Y-%m-%d)
+
+    # cleanup the destination
+    rm -rf "${DESTINATION}"
+
+    if [[ "${BUILD_DATE}" == "${TODAY}" || "${BUILD_DATE}" == "${YESTERDAY}" ]]; then
+        echo "[SUCCESS] Daily tarball '${TARBALL}' is up to date"
+        EXIT_CODE=0
+    else
+        echo "[ERROR] Daily tarball '${TARBALL}' is not up to date"
+        echo "[INFO] Tarball build date: ${BUILD_DATE}"
+        echo "[INFO] Today: ${BUILD_DATE}"
+        EXIT_CODE=1
+    fi
+done
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
Added CI pipeline to check whether the daily-master-qa tarball is up to date or not. The tarball is considered up to date if its build date is `today` or `yesterday` 's date.

Test runs:
Passing: https://drone.owncloud.com/owncloud/activity/3118/1/2
Failing: https://drone.owncloud.com/owncloud/activity/3117/1/2

Fixes https://github.com/owncloud/QA/issues/760