### PR TITLE
Adjust elasticsearch url and validateDailyTarballBuild

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1959,7 +1959,7 @@ def setupElasticSearch(esVersion):
             "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
             "commands": [
                 "cd %s" % dir["server"],
-                "php occ config:app:set search_elastic servers --value elasticsearch",
+                "php occ config:app:set search_elastic servers --value http://elasticsearch:9200",
                 "php occ search:index:reset --force",
             ],
         },

--- a/.drone.star
+++ b/.drone.star
@@ -46,6 +46,7 @@ config = {
         "master",
     ],
     "codestyle": True,
+    "validateDailyTarball": True,
     "phpstan": True,
     "phan": {
         "multipleVersions": {
@@ -2342,6 +2343,12 @@ def skipIfUnchanged(ctx, type):
     return []
 
 def validateDailyTarballBuild():
+    if "validateDailyTarball" not in config:
+        return []
+
+    if not config["validateDailyTarball"]:
+        return []
+
     pipeline = {
         "kind": "pipeline",
         "type": "docker",


### PR DESCRIPTION
1) https://github.com/owncloud/search_elastic/commit/fe9598651d032188ed9961d7aaf05925c5813f91 adjusted the elasticsearch URL in `.drone.star`. Makae the same change here to keep the code in the activity app up-to-date

2) Add logic so that validateDailyTarballBuild is only done if it is set in the drone config. That will allow us to copy the code the same when we copy to other oC10 app repos, and to control that pipeline from the drone config.