### PR TITLE
[tests-only] [full-ci] Update vendor-bin dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -29,7 +29,7 @@
                 "composer/composer": "^2.0",
                 "ext-json": "*",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.1",
                 "phpunit/phpunit": "^8.5 || ^9.5",
                 "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "behat/behat": "^3.11",
+        "behat/behat": "^3.13",
         "behat/gherkin": "^4.9",
         "behat/mink": "1.7.1",
         "friends-of-behat/mink-extension": "^2.7",
@@ -16,7 +16,7 @@
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^7.5",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "helmich/phpunit-json-assert": "^3.4"
     }
 }

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "owncloud/coding-standard": "^4.0"
+        "owncloud/coding-standard": "^4.1"
     }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^1.9"
+        "phpstan/phpstan": "^1.10"
     }
 }


### PR DESCRIPTION
## Description
I just made a new release 4.1.0 of owncloud coding-standard https://github.com/owncloud/coding-standard/releases/tag/4.1.0

That uses a newer version of php-cs-fixer, which passes locally for me.

This PR updates the version numbers of dependencies in `vendor-bin` to the current minor versions that are in use. That can be helpful when there are problems with some new release of a dependency - at least we have "documented" which minor version is currently working correctly.

## How Has This Been Tested?
CI
