### PR TITLE
[full-ci] [tests-only] Remove 'dispatch' message from phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,10 +7,6 @@ parameters:
       path: appinfo/routes.php
       count: 1
     -
-      message: '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required.#'
-      path: lib/AppInfo/Application.php
-      count: 1
-    -
       message: '#Comparison operation ">" between int<1, max> and 0 is always true.#'
       path: lib/Command/SendEmails.php
       count: 1


### PR DESCRIPTION
Fixes #1174 

The code for the `EventDispatcherInterface::dispatch` had already been updated for the Symfony 5 parameter order. Now that Symfony 5 is really in use in oC10 core, `phpstan` no longer complains about the order of the parameters.

Remove the error from `ignoreErrors` in `phpstan.neon`