### PR TITLE
Readd time to mail for non-expiry activities

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,12 +1,10 @@
 BANST_AWS_CLI = "banst/awscli"
-DRONE_CLI = "drone/cli:alpine"
 INBUCKET_INBUCKET = "inbucket/inbucket"
 MINIO_MC = "minio/mc:RELEASE.2020-12-18T10-53-53Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
 OC_CI_CEPH = "owncloudci/ceph:tag-build-master-jewel-ubuntu-16.04"
 OC_CI_CORE = "owncloudci/core"
-OC_CI_DRONE_CANCEL_PREVIOUS_BUILDS = "owncloudci/drone-cancel-previous-builds"
 OC_CI_DRONE_SKIP_PIPELINE = "owncloudci/drone-skip-pipeline"
 OC_CI_NODEJS = "owncloudci/nodejs:%s"
 OC_CI_ORACLE_XE = "owncloudci/oracle-xe:latest"
@@ -207,7 +205,7 @@ def main(ctx):
     return before + coverageTests + afterCoverageTests + nonCoverageTests + stages + after
 
 def beforePipelines(ctx):
-    return validateDailyTarballBuild() + codestyle(ctx) + jscodestyle(ctx) + cancelPreviousBuilds() + phpstan(ctx) + phan(ctx) + phplint(ctx) + checkStarlark()
+    return validateDailyTarballBuild() + codestyle(ctx) + jscodestyle(ctx) + phpstan(ctx) + phan(ctx) + phplint(ctx) + checkStarlark()
 
 def coveragePipelines(ctx):
     # All unit test pipelines that have coverage or other test analysis reported
@@ -360,31 +358,6 @@ def jscodestyle(ctx):
     pipelines.append(result)
 
     return pipelines
-
-def cancelPreviousBuilds():
-    return [{
-        "kind": "pipeline",
-        "type": "docker",
-        "name": "cancel-previous-builds",
-        "clone": {
-            "disable": True,
-        },
-        "steps": [{
-            "name": "cancel-previous-builds",
-            "image": OC_CI_DRONE_CANCEL_PREVIOUS_BUILDS,
-            "settings": {
-                "DRONE_TOKEN": {
-                    "from_secret": "drone_token",
-                },
-            },
-        }],
-        "depends_on": [],
-        "trigger": {
-            "ref": [
-                "refs/pull/**",
-            ],
-        },
-    }]
 
 def phpstan(ctx):
     pipelines = []
@@ -1265,7 +1238,7 @@ def acceptance(ctx):
                                          "path": "%s/downloads" % dir["server"],
                                      }],
                                  }),
-                             ] + testConfig["extraTeardown"] + githubComment(params["earlyFail"]) + stopBuild(ctx, params["earlyFail"]),
+                             ] + testConfig["extraTeardown"] + githubComment(params["earlyFail"]),
                     "services": databaseService(testConfig["database"]) +
                                 browserService(testConfig["browser"]) +
                                 emailService(testConfig["emailNeeded"]) +
@@ -2097,33 +2070,6 @@ def buildTestConfig(params):
                             config["runPart"] = runPart
                             configs.append(config)
     return configs
-
-def stopBuild(ctx, earlyFail):
-    if (earlyFail):
-        return [{
-            "name": "stop-build",
-            "image": DRONE_CLI,
-            "environment": {
-                "DRONE_SERVER": "https://drone.owncloud.com",
-                "DRONE_TOKEN": {
-                    "from_secret": "drone_token",
-                },
-            },
-            "commands": [
-                "drone build stop owncloud/%s ${DRONE_BUILD_NUMBER}" % ctx.repo.name,
-            ],
-            "when": {
-                "status": [
-                    "failure",
-                ],
-                "event": [
-                    "pull_request",
-                ],
-            },
-        }]
-
-    else:
-        return []
 
 def githubComment(earlyFail):
     if (earlyFail):

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -257,9 +257,16 @@ class MailQueueHandler {
 				->setTimestamp($activity['amq_timestamp'])
 				->setSubject($activity['amq_subject'], []);
 
-			$relativeDateTime = $this->dateFormatter->formatDateRelativeDay(
+			$relativeDate = $this->dateFormatter->formatDateRelativeDay(
 				$activity['amq_timestamp'],
 				'long',
+				new \DateTimeZone($timezone),
+				$l
+			);
+			$relativeDateTime = $this->dateFormatter->formatDateTimeRelativeDay(
+				$activity['amq_timestamp'],
+				'long',
+				'short',
 				new \DateTimeZone($timezone),
 				$l
 			);
@@ -270,14 +277,25 @@ class MailQueueHandler {
 				$this->dataHelper->getParameters($event, 'subject', $activity['amq_subjectparams'])
 			);
 
-			$activityListPlain[] = [
-				$plainParser->parseMessage($message),
-				$relativeDateTime,
-			];
-			$activityListHtml[] = [
-				$htmlParser->parseMessage($message),
-				$relativeDateTime,
-			];
+			if ((strpos($activity['amq_subjectparams'], 'shareExpired') !== false)) {
+				$activityListPlain[] = [
+					$plainParser->parseMessage($message),
+				        $relativeDate,
+				];
+				$activityListHtml[] = [
+					$htmlParser->parseMessage($message),
+					$relativeDate,
+				];
+			} else {
+				$activityListPlain[] = [
+					$plainParser->parseMessage($message),
+				        $relativeDateTime,
+				];
+				$activityListHtml[] = [
+					$htmlParser->parseMessage($message),
+					$relativeDateTime,
+				];
+			}
 		}
 
 		$alttext = new Template('activity', 'email.notification', '', false);

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -280,7 +280,7 @@ class MailQueueHandler {
 			if ((strpos($activity['amq_subjectparams'], 'shareExpired') !== false)) {
 				$activityListPlain[] = [
 					$plainParser->parseMessage($message),
-				        $relativeDate,
+					$relativeDate,
 				];
 				$activityListHtml[] = [
 					$htmlParser->parseMessage($message),
@@ -289,7 +289,7 @@ class MailQueueHandler {
 			} else {
 				$activityListPlain[] = [
 					$plainParser->parseMessage($message),
-				        $relativeDateTime,
+					$relativeDateTime,
 				];
 				$activityListHtml[] = [
 					$htmlParser->parseMessage($message),


### PR DESCRIPTION
In https://github.com/owncloud/activity/pull/1118 we removed the time from the notification emails because of the confusion generated by the activity time for shares expiry.

However, this caused the timestamp to be removed for all activity notifications. This PR adds logic for having the correct date format depending on the activity type (expiration vs non-expiration).