### PR TITLE
chore: bump security related js vendor dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
 		"karma-jasmine-sinon": "^1.0.4",
 		"karma-phantomjs-launcher": "*"
 	},
+	"resolutions": {
+		"minimist": "0.2.4",
+		"json-schema": "0.4.0",
+		"qs": "json-schema"
+	},
 	"engine": "node >= 0.8"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,9 +672,10 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+json-schema@0.2.3, json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -840,14 +841,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@0.0.8, minimist@0.2.4, minimist@^1.2.5:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.4.tgz#0085d5501e29033748a2f2a4da0180142697a475"
+  integrity sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==
 
 mkdirp@0.5.1:
   version "0.5.1"


### PR DESCRIPTION
## Description

Bump security related vendor js dependencies, some dependencies still do not have fixed the peer dependency.

## Overview

https://github.com/owncloud/activity/security/dependabot

## Details

### Prototype Pollution in minimist

https://github.com/owncloud/activity/security/dependabot/16, no upstream solution available, bumped via yarn resolutions

### json-schema is vulnerable to Prototype Pollution

https://github.com/owncloud/activity/security/dependabot/5, no upstream solution available, bumped via yarn resolutions

### json-schema is vulnerable to Prototype Pollution

https://github.com/owncloud/activity/security/dependabot/13, no upstream solution available, bumped via yarn resolutions