### PR TITLE
[tets-only] use updated link-share methods to get data

### DIFF
--- a/tests/acceptance/features/bootstrap/ActivityContext.php
+++ b/tests/acceptance/features/bootstrap/ActivityContext.php
@@ -296,10 +296,10 @@ class ActivityContext implements Context {
 			$this->addOwnCloudServerToThePublicLink(
 				$this->featureContext->getLocalBaseUrl(),
 				$user,
-				$this->featureContext->getLastPublicShareToken(),
-				$this->featureContext->getLastPublicShareAttribute("uid_owner"),
-				$this->featureContext->getLastPublicShareAttribute("displayname_owner"),
-				$this->featureContext->getLastPublicShareAttribute("path")
+				(string)$this->featureContext->getLastCreatedPublicShareToken(),
+				(string)$this->featureContext->getLastCreatedPublicShare()->uid_owner,
+				(string)$this->featureContext->getLastCreatedPublicShare()->displayname_owner,
+				(string)$this->featureContext->getLastCreatedPublicShare()->path
 			)
 		);
 	}


### PR DESCRIPTION
Methods to get the created link share data was changed in PR https://github.com/owncloud/core/pull/40919. I have changed the tests with the updated methods

Fixes https://github.com/owncloud/activity/issues/1193