### PR TITLE
[tests-only] fix: drop usage of ${}

### DIFF
--- a/tests/acceptance/features/bootstrap/ActivityContext.php
+++ b/tests/acceptance/features/bootstrap/ActivityContext.php
@@ -197,7 +197,7 @@ class ActivityContext implements Context {
 	): array {
 		$user = $this->featureContext->getActualUsername($user);
 		$objectId = $this->featureContext->getFileIdForPath($user, $resource);
-		$url = "/index.php/apps/activity/api/v2/activity/filter?object_type=files&object_id=${objectId}";
+		$url = "/index.php/apps/activity/api/v2/activity/filter?object_type=files&object_id=$objectId";
 		return $this->sendActivityGetRequest($url, $user);
 	}
 


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995

This syntax was only in the test code, so there is no need to make sure a release happens etc.