### PR TITLE
feat: add dist build workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,16 @@
+name: Build dist
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  build:
+    uses: owncloud/reusable-workflows/.github/workflows/build.yml@main


### PR DESCRIPTION
Adopts the reusable `build` workflow from [owncloud/reusable-workflows](https://github.com/owncloud/reusable-workflows) to run `make dist` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)