### PR TITLE
chore(ci): pass app-name to build workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -14,3 +14,5 @@ permissions: {}
 jobs:
   build:
     uses: owncloud/reusable-workflows/.github/workflows/build.yml@main
+    with:
+      app-name: 'activity'


### PR DESCRIPTION
To fix:
https://github.com/owncloud/activity/actions/runs/24326294454
```

Invalid workflow file: .github/workflows/dist.yml#L16
The workflow is not valid. .github/workflows/dist.yml (Line: 16, Col: 11): Input app-name is required, but not provided while calling.
```
