### PR TITLE
chore(ci): fix permissions for build dist workflow

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -9,7 +9,8 @@ on:
       - synchronize
       - reopened
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
needs to be given read permission, similar to in other PRs such as:
https://github.com/owncloud/configreport/pull/218/changes