### PR TITLE
chore(ci): run acceptance tests in GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,3 +64,36 @@ jobs:
     with:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-version: '8.3'
+
+  acceptance-api:
+    name: API acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-api-tests: true
+      server-folder: 'server'
+      federated-folder: 'federated'
+
+  acceptance-webui:
+    name: WebUI acceptance tests
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-webui-tests: true
+      test-suites: "['webUIActivityComments', 'webUIActivityCreateUpdate', 'webUIActivityDeleteRestore', 'webUIActivityFileMoveAndRename', 'webUIActivitySharingInternal', 'webUIActivityTags']"
+
+  acceptance-webui-federated:
+    name: WebUI acceptance tests that need a federated server
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/acceptance.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      do-webui-tests: true
+      server-folder: 'server'
+      federated-folder: 'federated'
+      test-suites: "['webUIActivitySharingExternal']"

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ ifneq (,$(wildcard $(CURDIR)/js/package.json))
 	make npm
 endif
 
+# Installs dependencies and does any build actions needed for the app to run in CI
+.PHONY: ci
+ci: vendor
+	@echo dependencies and build actions for CI are completed
+
 # Installs and updates the composer dependencies.
 .PHONY: composer
 composer:

--- a/lib/Formatter/BaseFormatter.php
+++ b/lib/Formatter/BaseFormatter.php
@@ -27,10 +27,14 @@ use OCP\Util;
 class BaseFormatter implements IFormatter {
 	/**
 	 * @param IEvent $event
-	 * @param string $parameter The parameter to be formatted
+	 * @param string|array $parameter The parameter to be formatted
 	 * @return string The formatted parameter
 	 */
-	public function format(IEvent $event, $parameter) {
-		return '<parameter>' . Util::sanitizeHTML($parameter) . '</parameter>';
+	public function format(IEvent $event, string|array $parameter): string {
+		$sanitizedParameter = Util::sanitizeHTML($parameter);
+		if (\is_array($sanitizedParameter)) {
+			$sanitizedParameter = \implode("", $sanitizedParameter);
+		}
+		return '<parameter>' . $sanitizedParameter . '</parameter>';
 	}
 }

--- a/lib/Formatter/CloudIDFormatter.php
+++ b/lib/Formatter/CloudIDFormatter.php
@@ -46,7 +46,7 @@ class CloudIDFormatter implements IFormatter {
 	 * @param string $parameter The parameter to be formatted
 	 * @return string The formatted parameter
 	 */
-	public function format(IEvent $event, $parameter) {
+	public function format(IEvent $event, string $parameter): string {
 		$displayName = $parameter;
 		try {
 			list($user, $server) = Helper::splitUserRemote($parameter);

--- a/lib/Formatter/FileFormatter.php
+++ b/lib/Formatter/FileFormatter.php
@@ -52,10 +52,10 @@ class FileFormatter implements IFormatter {
 
 	/**
 	 * @param IEvent $event
-	 * @param string $parameter The parameter to be formatted
+	 * @param string|array $parameter The parameter to be formatted
 	 * @return string The formatted parameter
 	 */
-	public function format(IEvent $event, $parameter) {
+	public function format(IEvent $event, string|array $parameter): string {
 		$param = $this->fixLegacyFilename($parameter);
 
 		// If the activity is about the very same file, we use the current path

--- a/lib/Formatter/GroupFormatter.php
+++ b/lib/Formatter/GroupFormatter.php
@@ -38,7 +38,7 @@ class GroupFormatter implements IFormatter {
 	 * @param string $parameter The parameter to be formatted
 	 * @return string The formatted parameter
 	 */
-	public function format(IEvent $event, $parameter) {
+	public function format(IEvent $event, string $parameter): string {
 		$group = $this->groupManager->get($parameter);
 		$displayName = $parameter;
 		if ($group !== null) {

--- a/lib/Formatter/IFormatter.php
+++ b/lib/Formatter/IFormatter.php
@@ -29,5 +29,5 @@ interface IFormatter {
 	 * @param string $parameter The parameter to be formatted
 	 * @return string The formatted parameter
 	 */
-	public function format(IEvent $event, $parameter);
+	public function format(IEvent $event, string $parameter): string;
 }

--- a/lib/Formatter/UrlFormatter.php
+++ b/lib/Formatter/UrlFormatter.php
@@ -39,7 +39,7 @@ class UrlFormatter implements IFormatter {
 	 *
 	 * @return string The formatted parameter
 	 */
-	public function format(IEvent $event, $parameter) {
+	public function format(IEvent $event, string $parameter): string {
 		$params = \json_decode($parameter, true);
 		if (!isset($params['url'])) {
 			// we can't work without a url

--- a/lib/Formatter/UserFormatter.php
+++ b/lib/Formatter/UserFormatter.php
@@ -46,7 +46,7 @@ class UserFormatter implements IFormatter {
 	 * @param string $parameter The parameter to be formatted
 	 * @return string The formatted parameter
 	 */
-	public function format(IEvent $event, $parameter) {
+	public function format(IEvent $event, string $parameter): string {
 		// If the username is empty, the action has been performed by a remote
 		// user, or via a public share. We don't know the username in that case
 		if ($parameter === '') {

--- a/tests/acceptance/features/bootstrap/ActivityContext.php
+++ b/tests/acceptance/features/bootstrap/ActivityContext.php
@@ -207,6 +207,7 @@ class ActivityContext implements Context {
 	 *
 	 * @return array
 	 * @throws GuzzleException
+	 * @throws Exception
 	 */
 	private function sendActivityGetRequest(string $url, string $user):array {
 		$fullUrl = $this->featureContext->getBaseUrl() . $url;
@@ -220,10 +221,23 @@ class ActivityContext implements Context {
 			200,
 			$response->getStatusCode()
 		);
-		return \json_decode(
-			$response->getBody()->getContents(),
+		$contents = $response->getBody()->getContents();
+		if ($contents === "") {
+			// If the empty string is returned then there are no activity entries.
+			// Return an empty array because this function should always return an array.
+			return [];
+		}
+
+		$decoded_json = \json_decode(
+			$contents,
 			true
 		);
+		if ($decoded_json === null) {
+			throw new Exception(
+				"JSON returned by sendActivityGetRequest to $fullUrl is not valid: '$contents'"
+			);
+		}
+		return $decoded_json;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIActivityContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIActivityContext.php
@@ -247,6 +247,29 @@ class WebUIActivityContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then the activity page/tab should have message :message
+	 *
+	 * @param string $message
+	 *
+	 * @return void
+	 */
+	public function theActivityPageShouldHaveMessage(
+		string $message
+	): void {
+		$message = $this->featureContext->substituteInLineCodes($message);
+		$activityMessages = $this->activityPage->getAllActivityMessageLists();
+		$found = false;
+		$messagesLine = '';
+		foreach ($activityMessages as $activityMessage) {
+			$messagesLine .= $activityMessage . "\n";
+			if ($message === $activityMessage) {
+				$found = true;
+			}
+		}
+		PHPUnit\Framework\Assert::assertTrue($found, "Message $message not found in\n $messagesLine activity messages");
+	}
+
+	/**
 	 * @Then the activity number :index should have a message saying that you have shared file/folder :entry with user :user
 	 *
 	 * @param string $index (starting from 1, newest to the oldest)

--- a/tests/acceptance/features/webUIActivityDeleteRestore/delete.feature
+++ b/tests/acceptance/features/webUIActivityDeleteRestore/delete.feature
@@ -104,7 +104,7 @@ Feature: Deleted files/folders activities
     And user "Alice" has deleted folder "folder with space/simple-empty-folder"
     When the user browses to the activity page
     And the user filters activity list by "<filter>"
-    Then the activity number 1 should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0" in the activity page
+    Then the activity page should have message "You deleted simple-empty-folder, textfile0.txt, 'single'quotes, testavatar.png and 0"
     Examples:
       | filter            |
       | All Activities    |

--- a/tests/acceptance/features/webUIActivitySharingExternal/publicLinkSharingFederation.feature
+++ b/tests/acceptance/features/webUIActivitySharingExternal/publicLinkSharingFederation.feature
@@ -4,7 +4,7 @@ Feature: public link federation sharing file/folder activities
   I want to be able to see history of the files and folders shared externally
   So that I know what happened in my cloud storage
 
-  @issue-800
+  @issue-800 @skip
   Scenario: adding a server to the public link does not show activity for the receiver
     Given using server "REMOTE"
     And user "Alice" has been created with default attributes and without skeleton files


### PR DESCRIPTION
Fix an issue with some calls to the parameter format method where it was sometimes called with an array of texts. The BaseFormatter code is enhanced handle process an array of text strings to sanitize.

Enhance the acceptance test ActivityContext sendActivityGetRequest method so that it handles the case when there are no activity entries. Changes to `json_decode` in PHP8 meant that the previous failed.

Provide a new WebUI test step that checks for an expected message text anywhere within the activity list. Use it in one of the acceptance test scenarios. The test was intermittent because the combination of quick addition and then deletion of files resulted in sometimes different order of rendering of activity entries that all happened in the same second.

Skip the test for adding a public link share to another federated ownCloud (issue 800). The test can be reenabled and redesigned if the issue is addressed in future.