### PR TITLE
test(ci): validate translation-sync git rm fix

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync:
-    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
+    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@fix/translation-cleanup-git-rm
     with:
       mode: old
       sub_path: l10n


### PR DESCRIPTION
## Summary

- Points the translation-sync workflow at the fix branch [owncloud/reusable-workflows#63](https://github.com/owncloud/reusable-workflows/pull/63) for manual validation
- Once the fix is confirmed working, this PR should be closed and the reusable-workflows PR merged to `main` (the `@main` pin in the workflow will then pick it up automatically)

## How to test

Trigger the workflow manually via **Actions → Translation Sync → Run workflow** on this branch and confirm the "Translation cleanup (old)" step no longer exits with code 123.

> **Note:** This PR is for testing only and should NOT be merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)