### PR TITLE
ci: make dependabot always produce convential-commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: npm
     directory: "/"
@@ -27,6 +30,9 @@ updates:
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -41,3 +47,6 @@ updates:
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
Should help with PRs like #1248

I think that dependabot "guesses" after a while by examining recent commits in a repo, so it might be doing "the right thing" already in some repos.
