### PR TITLE
test: bump phpstan to v2

### DIFF
--- a/lib/Command/SendEmails.php
+++ b/lib/Command/SendEmails.php
@@ -81,14 +81,11 @@ class SendEmails extends Command {
 		do {
 			$users = $this->mqHandler->getAllUsers(self::BATCH_SIZE);
 			$batchCount = \count($users);
-			if ($batchCount === 0) {
-				// queue is empty
-				break;
-			}
-
-			$this->sendBatch($users, $output);
-			if ($progress !== null) {
-				$progress->advance($batchCount);
+			if ($batchCount > 0) {
+				$this->sendBatch($users, $output);
+				if ($progress !== null) {
+					$progress->advance($batchCount);
+				}
 			}
 		} while ($batchCount > 0);
 

--- a/lib/Controller/OCSEndPoint.php
+++ b/lib/Controller/OCSEndPoint.php
@@ -56,7 +56,7 @@ class OCSEndPoint {
 	protected $objectId;
 
 	/** @var string */
-	protected $user;
+	protected $user = '';
 
 	/** @var bool */
 	protected $loadPreviews;

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -85,6 +85,7 @@ class Data {
 	 * @return bool
 	 */
 	public function send(IEvent $event) {
+		// @phpstan-ignore identical.alwaysFalse
 		if ($event->getAffectedUser() === '' || $event->getAffectedUser() === null) {
 			return false;
 		}
@@ -137,6 +138,7 @@ class Data {
 	 * @return bool
 	 */
 	public function storeMail(IEvent $event, $latestSendTime) {
+		// @phpstan-ignore identical.alwaysFalse
 		if ($event->getAffectedUser() === '' || $event->getAffectedUser() === null) {
 			return false;
 		}

--- a/lib/DataHelper.php
+++ b/lib/DataHelper.php
@@ -177,6 +177,7 @@ class DataHelper {
 	 * @return array List of Parameters
 	 */
 	public function parseParameters($parameterString) {
+		// @phpstan-ignore function.alreadyNarrowedType
 		if (!\is_string($parameterString)) {
 			return [];
 		}

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -681,6 +681,7 @@ class FilesHooks {
 		 */
 		$this->view->chroot('/' . $currentOwner . '/files');
 		$mount = $this->view->getMount($path);
+		// @phpstan-ignore instanceof.alwaysTrue
 		if (!($mount instanceof IMountPoint)) {
 			return;
 		}
@@ -742,6 +743,7 @@ class FilesHooks {
 			$event->setAuthor($agentAuthor);
 		}
 
+		// @phpstan-ignore identical.alwaysFalse
 		if ($event->getAuthor() === null) {
 			$event->setAuthor($this->currentUser);
 		}

--- a/lib/PlainTextParser.php
+++ b/lib/PlainTextParser.php
@@ -53,6 +53,8 @@ class PlainTextParser {
 	 * @return string
 	 */
 	protected function parseCollections($message) {
+		// @phpstan-ignore nullCoalesce.variable
+		$message = $message ?? '';
 		return \preg_replace_callback('/<collection>(.*?)<\/collection>/', function ($match) {
 			$parameterList = \explode('><', $match[1]);
 			$parameterListLength = \sizeof($parameterList);

--- a/lib/UserSettings.php
+++ b/lib/UserSettings.php
@@ -138,6 +138,7 @@ class UserSettings {
 	 *               Returns a "username => i:batchtime" Map for method = email
 	 */
 	public function filterUsersBySetting($users, $method, $type) {
+		// @phpstan-ignore function.alreadyNarrowedType
 		if (empty($users) || !\is_array($users)) {
 			return [];
 		}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,30 +3,18 @@ parameters:
     - %currentWorkingDirectory%/../../lib/base.php
   ignoreErrors:
     -
-      message: '#Variable \$this might not be defined.#'
+      rawMessage: 'Variable $this might not be defined.'
       path: appinfo/routes.php
       count: 1
     -
-      message: '#Comparison operation ">" between int<1, max> and 0 is always true.#'
-      path: lib/Command/SendEmails.php
-      count: 1
-    -
-      message: '#Strict comparison using === between non-empty-string and null will always evaluate to false.#'
-      path: lib/Data.php
-      count: 2
-    -
-      message: '#Method OCP\\DB\\QueryBuilder\\IExpressionBuilder::orX\(\) invoked with 2 parameters, 0-1 required.#'
+      rawMessage: 'Method OCP\DB\QueryBuilder\IExpressionBuilder::orX() invoked with 2 parameters, 0-1 required.'
       path: lib/Data.php
       count: 3
     -
-      message: '#Call to method getSharedFrom\(\) on an unknown class OC\\Files\\Storage\\Shared.#'
+      rawMessage: 'Call to method getSharedFrom() on an unknown class OC\Files\Storage\Shared.'
       path: lib/FilesHooks.php
       count: 1
     -
-      message: '#PHPDoc tag @var for variable \$storage contains unknown class OC\\Files\\Storage\\Shared.#'
-      path: lib/FilesHooks.php
-      count: 1
-    -
-      message: '#Strict comparison using === between string and null will always evaluate to false.#'
+      rawMessage: 'PHPDoc tag @var for variable $storage contains unknown class OC\Files\Storage\Shared.'
       path: lib/FilesHooks.php
       count: 1

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.4"
+        "phan/phan": "^5.5"
     }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^2.2"
     }
 }


### PR DESCRIPTION
PHPstan is updated from v1 to v2. v2 is the current version supported on PHP 8.

The format of ignored errors in phpstan.neon is changed to use the new rawMessage format. Previously the messages had to be encoded as regex strings. For oridnary text messages, the rawMessage form is much simpler.

Some ignored messages were moved into the code as phpstan-ignore comment lines. This associates the ignored message directly with the exact place in the code that generates the message. That will be helpful if/when code refactoring is being done to "fix" the code that generates the phpstan message.

The PHP unit tests were emitting some PHP deprecation messages. Code has been minimally refactored to avoid these.

There are no real production run-time fixes to make here. The purpose of this PR is to demonstrate the type of minimal changes that can be needed when updating from PHPstan v1 to v2. No rush to review or merge this.